### PR TITLE
Added BTC/EUR Applet

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,8 @@ SRC =  						src/main.py \
 							src/web_server.py \
 							src/system_applets/base_applet.py \
 							src/applets/bitcoin_applet.py \
-			  			src/urllib_urequest.py \
+							src/applets/bitcoin_euro_applet.py \
+			  				src/urllib_urequest.py \
 							src/applets/block_height_applet.py \
 							src/applets/halving_countdown_applet.py \
 							src/applets/fee_applet.py \

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -8,6 +8,7 @@ from system_applets.splash_applet import SplashApplet
 from system_applets.error_applet import ErrorApplet
 from applets import (
     bitcoin_applet,
+    bitcoin_eur_applet,
     block_height_applet,
     fee_applet,
     moscow_time_applet,
@@ -48,6 +49,7 @@ class AppletManager:
 
         self.all_applets = {
             "bitcoin_applet": bitcoin_applet.bitcoin_applet,
+            "bitcoin_eur_applet": bitcoin_eur_applet.bitcoin_eur_applet,
             "block_height_applet": block_height_applet.mempool_applet,
             "fee_applet": fee_applet.fee_applet,
             "moscow_time_applet": moscow_time_applet.moscow_time_applet,

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -4,13 +4,13 @@ from data_manager import DataManager
 from micropython import const
 import gc
 
-class bitcoin_applet(BaseApplet):
+class bitcoin_eur_applet(BaseApplet):
     TTL = const(120)
 
     def __init__(self, screen_manager: ScreenManager, data_manager: DataManager):
-        super().__init__('bitcoin_applet', screen_manager)
+        super().__init__('bitcoin_eur_applet', screen_manager)
         self.data_manager = data_manager
-        self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
+        self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCEUR"
         self.drawn = False
         self.register()
 
@@ -33,7 +33,7 @@ class bitcoin_applet(BaseApplet):
             return
 
         self.screen_manager.clear()
-        self.screen_manager.draw_header("Bitcoin US Dollar Price")
+        self.screen_manager.draw_header("Bitcoin Euro Price")
         self.data = self.data_manager.get_cached_data(self.api_url)
 
         print("Initial cached data:", self.data)
@@ -55,12 +55,12 @@ class bitcoin_applet(BaseApplet):
 
             if price:
                 try:
-                    usd_price = float(price)
+                    eur_price = float(price)
                     change = float(change_percent)
 
                     # Draw the label, price and change
-                    self.screen_manager.draw_centered_text("BTC/USD", scale=3, y_offset=-60)  # Label above price
-                    self.screen_manager.draw_centered_text(f"${int(usd_price):,}")  # Price with default scale=8 and thousand separator
+                    self.screen_manager.draw_centered_text("BTC/EUR", scale=3, y_offset=-60)  # Label above price
+                    self.screen_manager.draw_centered_text(f"E{int(eur_price):,}")  # Price with default scale=8 and thousand separator
                     # Draw the change percentage
                     change_text = f"24h change: {change:+.2f}%"
                     text_width = self.screen_manager.display.measure_text(change_text, scale=2)


### PR DESCRIPTION
I have added an applet to the Bitcoin Ticker similar to the BTC/USD applet displaying the BTC/EUR pair. 

To do so there are changes to these files:
- makefile
- src/applet_manager.py
- src/applets/bitcoin_applet.py (to change header to BITCOIN US DOLLAR PRICE) 
- - src/applets/bitcoin_eur_applet.py (new)