### PR TITLE
Added functionality to set applet display duration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ This is a fully open source project that you can build yourself! We've designed 
 A Bitcoin price and blockchain information display built with Raspberry Pi Pico W and Pimoroni Display Pack 2.8.
 
 ## ✨ Features
-
+ 
 - 💰 Real-time Bitcoin price display (BTC/USD)
 - 💰 Real-time Bitcoin price display (BTC/EUR)
 - ⛓️ Current Bitcoin blockchain height display

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ A Bitcoin price and blockchain information display built with Raspberry Pi Pico 
 ## ✨ Features
 
 - 💰 Real-time Bitcoin price display (BTC/USD)
+- 💰 Real-time Bitcoin price display (BTC/EUR)
 - ⛓️ Current Bitcoin blockchain height display
 - 📊 Bitcoin Mempool status
 - 🕰️ Moscow Time display
@@ -76,24 +77,26 @@ The most difficult part to complete at home. All necessary files and measurement
 ### Project Structure
 ```
 src/
-├── applets/                # Bitcoin information displays
-│   ├── bitcoin_applet.py   # BTC price display
+├── applets/                    # Bitcoin information displays
+│   ├── bitcoin_applet.py       # BTC / Dollar price display
+│   ├── bitcoin_eur_applet.py   # BTC / Euro price display
 │   ├── block_height_applet.py
 │   ├── fee_applet.py
 │   ├── halving_countdown_applet.py
 │   └── moscow_time_applet.py
-├── system_applets/         # Core system applets
-│   ├── ap_applet.py        # Access point configuration screen
-│   ├── base_applet.py      # Base class for all applets
-│   ├── error_applet.py     # Error display screen
-│   └── splash_applet.py    # Boot splash screen
-├── applet_manager.py       # Manages applet lifecycle
-├── data_manager.py         # Handles API requests and caching
-├── main.py                 # Application entry point
-├── screen_manager.py       # Display abstraction
-├── urllib_urequest.py      # HTTP client
-├── web_server.py           # Configuration web interface
-└── wifi_manager.py         # Network connection manager
+├── system_applets/             # Core system applets
+│   ├── ap_applet.py            # Access point configuration screen
+│   ├── base_applet.py          # Base class for all applets
+│   ├── error_applet.py         # Error display screen
+│   └── splash_applet.py        # Boot splash screen
+├── applet_manager.py           # Manages applet lifecycle
+├── data_manager.py             # Handles API requests and caching
+├── main.py                     # Application entry point
+├── screen_manager.py           # Display abstraction
+├── urllib_urequest.py          # HTTP client
+├── web_server.py               # Configuration web interface
+└── wifi_manager.py             # Network connection manager
+└── config.py                   # Utility to help manage configurations
 ```
 
 ### Dependencies

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -3,6 +3,7 @@ import os
 from system_applets import base_applet
 import uasyncio as asyncio
 import json
+import time
 
 from system_applets.splash_applet import SplashApplet
 from system_applets.error_applet import ErrorApplet
@@ -14,22 +15,11 @@ from applets import (
     moscow_time_applet,
     halving_countdown_applet
 )
+from config import ConfigManager
 
 
 class AppletManager:
-    """
-    Manages the lifecycle of different applets, including their initialization,
-    updates, drawing on screen, and error handling.
-    """
-
     def __init__(self, screen_manager, data_manager, wifi_manager) -> None:
-        """
-        Initialize the AppletManager with managers for screen, data, and Wi-Fi.
-
-        :param screen_manager: Manages the physical or virtual display.
-        :param data_manager:   Manages data fetching and distribution.
-        :param wifi_manager:   Manages Wi-Fi connectivity (e.g., credentials, connection status).
-        """
         self.screen_manager = screen_manager
         self.data_manager = data_manager
         self.wifi_manager = wifi_manager
@@ -40,13 +30,12 @@ class AppletManager:
 
         self.next_applet_data = None
 
+        gc.collect()
+        self.config_manager = ConfigManager()
+
         self._register_applets()
 
     def _register_applets(self) -> None:
-        """
-        Instantiate and store the available applets.
-        """
-
         self.all_applets = {
             "bitcoin_applet": bitcoin_applet.bitcoin_applet,
             "bitcoin_eur_applet": bitcoin_eur_applet.bitcoin_eur_applet,
@@ -55,51 +44,28 @@ class AppletManager:
             "moscow_time_applet": moscow_time_applet.moscow_time_applet,
             "halving_countdown_applet": halving_countdown_applet.halving_countdown_applet,
         }
-
         self.applets = self.load_applets()
 
     def update_applets(self, applets, filename="applets.json"):
-        """
-        Save the applets to a file.
-        """
         with open(filename, "w") as f:
             data = []
             for applet in applets:
-                # Add the valid applet to the data list
-                data.append({
-                    "name": applet["name"],
-                    "enabled": applet["enabled"]
-                })
-            # Save the valid data to the file
+                data.append({"name": applet["name"], "enabled": applet["enabled"]})
             json.dump(data, f)
 
     def get_applets_list(self):
-        """
-        Return a list of applets with their names and enabled status.
-        """
         applets = []
         for applet in self.applets:
-            applets.append({
-                "name": applet.__class__.__name__,
-                "enabled": True
-            })
+            applets.append({"name": applet.__class__.__name__, "enabled": True})
         for applet_name in self.all_applets.keys():
             if applet_name not in [applet["name"] for applet in applets]:
-                applets.append({
-                    "name": applet_name,
-                    "enabled": False
-                })
+                applets.append({"name": applet_name, "enabled": False})
         return applets
 
     def load_applets(self, filename="applets.json"):
-        """
-        Load or create a simple list of applets with 'name' and 'enabled' keys,
-        then instantiate them. Missing default applets from self.all_applets
-        are added automatically.
-        """
         try:
             with open(filename, "r") as f:
-                data = json.load(f)  # Expecting a list of { "name": str, "enabled": bool }
+                data = json.load(f)
                 print(f"[AppletManager] Loaded applets from {filename}")
         except OSError:
             print(f"[AppletManager] Failed to load applets from {filename}. Starting with defaults.")
@@ -114,7 +80,6 @@ class AppletManager:
                 data.append({"name": applet_name, "enabled": True})
             self.update_applets(data)
 
-        # Init enabled applets
         applets = []
         for applet in data:
             if not applet.get('enabled', False):
@@ -130,21 +95,10 @@ class AppletManager:
             applets.append(applet_class(self.screen_manager, self.data_manager))
         return applets
 
-
-
     def _get_applet_class(self, name):
-        """
-        Map applet names to their respective classes.
-        This allows applets to be instantiated dynamically based on their name.
-        """
         return self.all_applets.get(name)
 
-
     async def start_applets(self) -> None:
-        """
-        Entry point to start the applets in a continuous loop.
-        This method is typically called once after system initialization.
-        """
         enabled_applets = self.applets
 
         if not enabled_applets:
@@ -157,16 +111,9 @@ class AppletManager:
         while self.running:
             current_applet = enabled_applets[self.current_index]
             await self._run_applet(current_applet)
-            # Advance to the next applet
             self.current_index = (self.current_index + 1) % len(enabled_applets)
 
     async def _run_applet(self, applet, is_system_applet: bool = False) -> None:
-        """
-        Core method to run a single applet in a loop until it requests an advance or an error occurs.
-
-        :param applet:           The applet to run.
-        :param is_system_applet: If True, the applet is a system applet like Splash or Error.
-        """
         gc.collect()
         print(f"[AppletManager] Starting applet: {applet.__class__.__name__}")
 
@@ -177,29 +124,33 @@ class AppletManager:
         self.current_applet = applet
         self.current_applet.start()
 
+        applet_duration = max(3, self.config_manager.get_applet_duration())
+        #applet_duration = self.config_manager.get_applet_duration()
+        print(f"[AppletManager] Using applet duration: {applet_duration} seconds")
+
         self.running = True
+
         try:
+            start = time.ticks_ms()
             while self.running:
-                should_advance = await self.current_applet.update()
+                await self.current_applet.update()
                 await self.current_applet.draw()
                 self.screen_manager.update()
 
-                if should_advance and not is_system_applet:
+                elapsed = time.ticks_diff(time.ticks_ms(), start) / 1000
+                if elapsed >= applet_duration and not is_system_applet:
+                    print(f"[AppletManager] Duration expired after {elapsed:.2f}s")
                     await self._advance_to_next_applet()
                     break
 
-                await asyncio.sleep(10)
+                await asyncio.sleep(0.1)
 
         except Exception as e:
             await self._handle_exception(e)
-
         finally:
             gc.collect()
 
     async def run_applet_once(self, applet) -> None:
-        """
-        Run a single applet once 
-        """
         gc.collect()
         print(f"[AppletManager] Starting applet: {applet.__class__.__name__}")
         if self.current_applet:
@@ -216,16 +167,11 @@ class AppletManager:
             gc.collect()
 
     async def _advance_to_next_applet(self) -> None:
-        """
-        Advances to the next applet in the sequence, wrapping around if needed.
-        """
         if not self.applets:
             print("[AppletManager] No applets to advance to.")
             return
 
         self.current_index = (self.current_index + 1) % len(self.applets)
-
-        # Pass any preloaded data to the next applet
         next_applet = self.applets[self.current_index]
         if self.next_applet_data:
             next_applet.set_preloaded_data(self.next_applet_data)
@@ -234,30 +180,16 @@ class AppletManager:
         print(f"[AppletManager] Advancing to applet: {next_applet.__class__.__name__}")
 
     async def _display_error(self, message: str) -> None:
-        """
-        Display an error applet with the provided message.
-
-        :param message: The error message to display.
-        """
         error_applet = ErrorApplet(self.screen_manager, message)
         await self._run_applet(error_applet, is_system_applet=True)
 
     async def _handle_exception(self, exception: Exception) -> None:
-        """
-        Handle exceptions by displaying an error applet, stopping the current loop,
-        and preventing further updates to the crashed applet.
-
-        :param exception: The caught exception.
-        """
         print(f"[AppletManager] Exception occurred: {exception}")
         if self.current_applet:
             self.current_applet.stop()
 
         error_message = str(exception)
         error_applet = ErrorApplet(self.screen_manager, error_message)
-
-        # Switch to error applet
         await self._run_applet(error_applet, is_system_applet=True)
-
-        # Stop the main loop to avoid repeated crashes
         self.running = False
+

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -125,7 +125,6 @@ class AppletManager:
         self.current_applet.start()
 
         applet_duration = max(3, self.config_manager.get_applet_duration())
-        #applet_duration = self.config_manager.get_applet_duration()
         print(f"[AppletManager] Using applet duration: {applet_duration} seconds")
 
         self.running = True

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,56 @@
+import json
+import os
+
+class ConfigManager:
+    """
+    Manages configuration settings for the Bitcoin Ticker application.
+    Currently supports applet duration configuration.
+    """
+    
+    def __init__(self):
+        self.config = {}
+        self.filename = "config.json"
+        self.defaults = {
+            "applet_duration": 10  # Default duration in seconds
+        }
+        self.load_config()
+    
+    def load_config(self):
+        """Load configuration from file or create with defaults if it doesn't exist"""
+        try:
+            with open(self.filename, "r") as f:
+                self.config = json.load(f)
+                print(f"[ConfigManager] Loaded configuration from {self.filename}")
+        except (OSError, ValueError):
+            print(f"[ConfigManager] Failed to load configuration. Using defaults.")
+            self.config = self.defaults.copy()
+            self.save_config()
+    
+    def save_config(self):
+        """Save current configuration to file"""
+        with open(self.filename, "w") as f:
+            json.dump(self.config, f)
+            print(f"[ConfigManager] Saved configuration to {self.filename}")
+    
+    def get_applet_duration(self):
+        """Get the current applet duration in seconds"""
+        return self.config.get("applet_duration", self.defaults["applet_duration"])
+    
+    def set_applet_duration(self, duration):
+        """
+        Set and validate the applet duration
+        
+        :param duration: Duration in seconds (will be clamped between 3-60 seconds)
+        :return: The actual duration that was set after validation
+        """
+        try:
+            # Convert to integer and clamp between 3-60 seconds
+            duration = int(duration)
+            duration = max(3, min(60, duration))
+            
+            self.config["applet_duration"] = duration
+            self.save_config()
+            return duration
+        except (ValueError, TypeError):
+            # If conversion fails, return the current value
+            return self.get_applet_duration()


### PR DESCRIPTION
I have added functionality to make the duration of the applet rotation on screen configurable in the web gui. 

I have added:
- config.py -> to handle this config and perhaps other config at a later date

I have updated:
- applet_manager.py -> To retrieve the duration and add logic to stick to the duration for each screen rotation. 
- web_server.py -> New config section and input box and saving and fetching functions. Config is written to config.json.
 
    ![Screenshot from 2025-04-15 09-47-35](https://github.com/user-attachments/assets/b5de1dfe-a26a-443e-a81d-17ece9caa9aa)
