### PR TITLE
Bitcoin ticker timezone config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,9 @@ This is a fully open source project that you can build yourself! We've designed 
 A Bitcoin price and blockchain information display built with Raspberry Pi Pico W and Pimoroni Display Pack 2.8.
 
 ## ✨ Features
-
+ 
 - 💰 Real-time Bitcoin price display (BTC/USD)
+- 💰 Real-time Bitcoin price display (BTC/EUR)
 - ⛓️ Current Bitcoin blockchain height display
 - 📊 Bitcoin Mempool status
 - 🕰️ Moscow Time display
@@ -76,24 +77,26 @@ The most difficult part to complete at home. All necessary files and measurement
 ### Project Structure
 ```
 src/
-├── applets/                # Bitcoin information displays
-│   ├── bitcoin_applet.py   # BTC price display
+├── applets/                    # Bitcoin information displays
+│   ├── bitcoin_applet.py       # BTC / Dollar price display
+│   ├── bitcoin_eur_applet.py   # BTC / Euro price display
 │   ├── block_height_applet.py
 │   ├── fee_applet.py
 │   ├── halving_countdown_applet.py
 │   └── moscow_time_applet.py
-├── system_applets/         # Core system applets
-│   ├── ap_applet.py        # Access point configuration screen
-│   ├── base_applet.py      # Base class for all applets
-│   ├── error_applet.py     # Error display screen
-│   └── splash_applet.py    # Boot splash screen
-├── applet_manager.py       # Manages applet lifecycle
-├── data_manager.py         # Handles API requests and caching
-├── main.py                 # Application entry point
-├── screen_manager.py       # Display abstraction
-├── urllib_urequest.py      # HTTP client
-├── web_server.py           # Configuration web interface
-└── wifi_manager.py         # Network connection manager
+├── system_applets/             # Core system applets
+│   ├── ap_applet.py            # Access point configuration screen
+│   ├── base_applet.py          # Base class for all applets
+│   ├── error_applet.py         # Error display screen
+│   └── splash_applet.py        # Boot splash screen
+├── applet_manager.py           # Manages applet lifecycle
+├── data_manager.py             # Handles API requests and caching
+├── main.py                     # Application entry point
+├── screen_manager.py           # Display abstraction
+├── urllib_urequest.py          # HTTP client
+├── web_server.py               # Configuration web interface
+└── wifi_manager.py             # Network connection manager
+└── config.py                   # Utility to help manage configurations
 ```
 
 ### Dependencies

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -3,6 +3,7 @@ import os
 from system_applets import base_applet
 import uasyncio as asyncio
 import json
+import time
 
 from system_applets.splash_applet import SplashApplet
 from system_applets.error_applet import ErrorApplet
@@ -14,22 +15,11 @@ from applets import (
     moscow_time_applet,
     halving_countdown_applet
 )
+from config import ConfigManager
 
 
 class AppletManager:
-    """
-    Manages the lifecycle of different applets, including their initialization,
-    updates, drawing on screen, and error handling.
-    """
-
     def __init__(self, screen_manager, data_manager, wifi_manager) -> None:
-        """
-        Initialize the AppletManager with managers for screen, data, and Wi-Fi.
-
-        :param screen_manager: Manages the physical or virtual display.
-        :param data_manager:   Manages data fetching and distribution.
-        :param wifi_manager:   Manages Wi-Fi connectivity (e.g., credentials, connection status).
-        """
         self.screen_manager = screen_manager
         self.data_manager = data_manager
         self.wifi_manager = wifi_manager
@@ -40,13 +30,12 @@ class AppletManager:
 
         self.next_applet_data = None
 
+        gc.collect()
+        self.config_manager = ConfigManager()
+
         self._register_applets()
 
     def _register_applets(self) -> None:
-        """
-        Instantiate and store the available applets.
-        """
-
         self.all_applets = {
             "bitcoin_applet": bitcoin_applet.bitcoin_applet,
             "bitcoin_eur_applet": bitcoin_eur_applet.bitcoin_eur_applet,
@@ -55,51 +44,28 @@ class AppletManager:
             "moscow_time_applet": moscow_time_applet.moscow_time_applet,
             "halving_countdown_applet": halving_countdown_applet.halving_countdown_applet,
         }
-
         self.applets = self.load_applets()
 
     def update_applets(self, applets, filename="applets.json"):
-        """
-        Save the applets to a file.
-        """
         with open(filename, "w") as f:
             data = []
             for applet in applets:
-                # Add the valid applet to the data list
-                data.append({
-                    "name": applet["name"],
-                    "enabled": applet["enabled"]
-                })
-            # Save the valid data to the file
+                data.append({"name": applet["name"], "enabled": applet["enabled"]})
             json.dump(data, f)
 
     def get_applets_list(self):
-        """
-        Return a list of applets with their names and enabled status.
-        """
         applets = []
         for applet in self.applets:
-            applets.append({
-                "name": applet.__class__.__name__,
-                "enabled": True
-            })
+            applets.append({"name": applet.__class__.__name__, "enabled": True})
         for applet_name in self.all_applets.keys():
             if applet_name not in [applet["name"] for applet in applets]:
-                applets.append({
-                    "name": applet_name,
-                    "enabled": False
-                })
+                applets.append({"name": applet_name, "enabled": False})
         return applets
 
     def load_applets(self, filename="applets.json"):
-        """
-        Load or create a simple list of applets with 'name' and 'enabled' keys,
-        then instantiate them. Missing default applets from self.all_applets
-        are added automatically.
-        """
         try:
             with open(filename, "r") as f:
-                data = json.load(f)  # Expecting a list of { "name": str, "enabled": bool }
+                data = json.load(f)
                 print(f"[AppletManager] Loaded applets from {filename}")
         except OSError:
             print(f"[AppletManager] Failed to load applets from {filename}. Starting with defaults.")
@@ -114,7 +80,6 @@ class AppletManager:
                 data.append({"name": applet_name, "enabled": True})
             self.update_applets(data)
 
-        # Init enabled applets
         applets = []
         for applet in data:
             if not applet.get('enabled', False):
@@ -130,21 +95,10 @@ class AppletManager:
             applets.append(applet_class(self.screen_manager, self.data_manager))
         return applets
 
-
-
     def _get_applet_class(self, name):
-        """
-        Map applet names to their respective classes.
-        This allows applets to be instantiated dynamically based on their name.
-        """
         return self.all_applets.get(name)
 
-
     async def start_applets(self) -> None:
-        """
-        Entry point to start the applets in a continuous loop.
-        This method is typically called once after system initialization.
-        """
         enabled_applets = self.applets
 
         if not enabled_applets:
@@ -157,16 +111,9 @@ class AppletManager:
         while self.running:
             current_applet = enabled_applets[self.current_index]
             await self._run_applet(current_applet)
-            # Advance to the next applet
             self.current_index = (self.current_index + 1) % len(enabled_applets)
 
     async def _run_applet(self, applet, is_system_applet: bool = False) -> None:
-        """
-        Core method to run a single applet in a loop until it requests an advance or an error occurs.
-
-        :param applet:           The applet to run.
-        :param is_system_applet: If True, the applet is a system applet like Splash or Error.
-        """
         gc.collect()
         print(f"[AppletManager] Starting applet: {applet.__class__.__name__}")
 
@@ -177,29 +124,33 @@ class AppletManager:
         self.current_applet = applet
         self.current_applet.start()
 
+        applet_duration = max(3, self.config_manager.get_applet_duration())
+        #applet_duration = self.config_manager.get_applet_duration()
+        print(f"[AppletManager] Using applet duration: {applet_duration} seconds")
+
         self.running = True
+
         try:
+            start = time.ticks_ms()
             while self.running:
-                should_advance = await self.current_applet.update()
+                await self.current_applet.update()
                 await self.current_applet.draw()
                 self.screen_manager.update()
 
-                if should_advance and not is_system_applet:
+                elapsed = time.ticks_diff(time.ticks_ms(), start) / 1000
+                if elapsed >= applet_duration and not is_system_applet:
+                    print(f"[AppletManager] Duration expired after {elapsed:.2f}s")
                     await self._advance_to_next_applet()
                     break
 
-                await asyncio.sleep(10)
+                await asyncio.sleep(0.1)
 
         except Exception as e:
             await self._handle_exception(e)
-
         finally:
             gc.collect()
 
     async def run_applet_once(self, applet) -> None:
-        """
-        Run a single applet once 
-        """
         gc.collect()
         print(f"[AppletManager] Starting applet: {applet.__class__.__name__}")
         if self.current_applet:
@@ -216,16 +167,11 @@ class AppletManager:
             gc.collect()
 
     async def _advance_to_next_applet(self) -> None:
-        """
-        Advances to the next applet in the sequence, wrapping around if needed.
-        """
         if not self.applets:
             print("[AppletManager] No applets to advance to.")
             return
 
         self.current_index = (self.current_index + 1) % len(self.applets)
-
-        # Pass any preloaded data to the next applet
         next_applet = self.applets[self.current_index]
         if self.next_applet_data:
             next_applet.set_preloaded_data(self.next_applet_data)
@@ -234,30 +180,16 @@ class AppletManager:
         print(f"[AppletManager] Advancing to applet: {next_applet.__class__.__name__}")
 
     async def _display_error(self, message: str) -> None:
-        """
-        Display an error applet with the provided message.
-
-        :param message: The error message to display.
-        """
         error_applet = ErrorApplet(self.screen_manager, message)
         await self._run_applet(error_applet, is_system_applet=True)
 
     async def _handle_exception(self, exception: Exception) -> None:
-        """
-        Handle exceptions by displaying an error applet, stopping the current loop,
-        and preventing further updates to the crashed applet.
-
-        :param exception: The caught exception.
-        """
         print(f"[AppletManager] Exception occurred: {exception}")
         if self.current_applet:
             self.current_applet.stop()
 
         error_message = str(exception)
         error_applet = ErrorApplet(self.screen_manager, error_message)
-
-        # Switch to error applet
         await self._run_applet(error_applet, is_system_applet=True)
-
-        # Stop the main loop to avoid repeated crashes
         self.running = False
+

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,81 @@
+import json
+import os
+
+class ConfigManager:
+    """
+    Manages configuration settings for the Bitcoin Ticker application.
+    Currently supports applet duration and timezone offset configuration.
+    """
+    
+    def __init__(self):
+        self.config = {}
+        self.filename = "config.json"
+        self.defaults = {
+            "applet_duration": 10,  # Default duration in seconds
+            "timezone_offset": 0     # Default timezone offset (UTC)
+        }
+        self.load_config()
+    
+    def load_config(self):
+        """Load configuration from file or create with defaults if it doesn't exist"""
+        try:
+            with open(self.filename, "r") as f:
+                self.config = json.load(f)
+                print(f"[ConfigManager] Loaded configuration from {self.filename}")
+        except (OSError, ValueError):
+            print(f"[ConfigManager] Failed to load configuration. Using defaults.")
+            self.config = self.defaults.copy()
+            self.save_config()
+    
+    def save_config(self):
+        """Save current configuration to file"""
+        with open(self.filename, "w") as f:
+            json.dump(self.config, f)
+            print(f"[ConfigManager] Saved configuration to {self.filename}")
+    
+    def get_applet_duration(self):
+        """Get the current applet duration in seconds"""
+        return self.config.get("applet_duration", self.defaults["applet_duration"])
+    
+    def set_applet_duration(self, duration):
+        """
+        Set and validate the applet duration
+        
+        :param duration: Duration in seconds (will be clamped between 3-60 seconds)
+        :return: The actual duration that was set after validation
+        """
+        try:
+            # Convert to integer and clamp between 3-60 seconds
+            duration = int(duration)
+            duration = max(3, min(60, duration))
+            
+            self.config["applet_duration"] = duration
+            self.save_config()
+            return duration
+        except (ValueError, TypeError):
+            # If conversion fails, return the current value
+            return self.get_applet_duration()
+    
+    def get_timezone_offset(self):
+        """Get the current timezone offset from UTC in hours"""
+        return self.config.get("timezone_offset", self.defaults["timezone_offset"])
+    
+    def set_timezone_offset(self, offset):
+        """
+        Set and validate the timezone offset
+        
+        :param offset: Offset in hours from UTC (clamped between -12 and +14)
+        :return: The actual offset that was set after validation
+        """
+        try:
+            # Convert to integer and clamp between -12 and +14 hours
+            # (Valid timezone ranges from UTC-12 to UTC+14)
+            offset = int(offset)
+            offset = max(-12, min(14, offset))
+            
+            self.config["timezone_offset"] = offset
+            self.save_config()
+            return offset
+        except (ValueError, TypeError):
+            # If conversion fails, return the current value
+            return self.get_timezone_offset()

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from wifi_manager import WiFiManager
 from web_server import AsyncWebServer
 from applet_manager import AppletManager
 from system_applets import ap_applet
+from config import ConfigManager
 
 RGBLED(6, 7, 8).set_rgb(0, 0, 0)
 
@@ -18,7 +19,8 @@ async def main() -> None:
     and starts the web server. It keeps an asynchronous loop alive to service
     other tasks such as applets and data retrieval.
     """
-    screen_manager = ScreenManager()
+    config_manager = ConfigManager()
+    screen_manager = ScreenManager(config_manager=config_manager)
     data_manager = DataManager()
     wifi_manager = WiFiManager()
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -3,6 +3,7 @@ import applet_manager
 import uasyncio as asyncio
 import json
 import wifi_manager  # Your custom WiFiManager module
+from config import ConfigManager  # Added import for ConfigManager
 
 def safe_convert_to_int(value, default=0) -> int:
     """
@@ -28,6 +29,9 @@ class AsyncWebServer:
         self.wifi_manager = wifi_manager
         self.applet_manager = applet_manager
         self.ip_address = self.wifi_manager.ip
+        
+        # Initialize config manager
+        self.config_manager = ConfigManager()
 
         # Example: define your known applets
         self.applets = self.applet_manager.get_applets_list()
@@ -35,13 +39,16 @@ class AsyncWebServer:
             "GET /": self.handle_root,  # Serve the main HTML page
             "GET /networks": self.handle_get_networks,
             "GET /applets": self.handle_get_applets,
+            "GET /config": self.handle_get_config,  # New route to fetch config
             "POST /submit": self.handle_submit_network,
             "POST /move_up": self.handle_move_up,
             "POST /move_down": self.handle_move_down,
             "POST /remove": self.handle_remove_network,
             "POST /select_applets": self.handle_select_applets,
+            "POST /update_config": self.handle_update_config,  # New route to update config
             "POST /reboot": self.handle_reboot,
         }
+        
     async def handle_root(self, request_lines, writer):
         html = self.web_page()
         response = (
@@ -62,8 +69,24 @@ class AsyncWebServer:
         )
         writer.write(response.encode('utf-8'))
         await writer.drain()
+        
     async def handle_get_applets(self, request_lines, writer):
         response_body = json.dumps(self.applets)
+        response = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json\r\n"
+            "Connection: close\r\n\r\n" + response_body
+        )
+        writer.write(response.encode('utf-8'))
+        await writer.drain()
+    
+    async def handle_get_config(self, request_lines, writer):
+        """Handle GET request for configuration settings"""
+        config = {
+            "applet_duration": self.config_manager.get_applet_duration(),
+            "timezone_offset": self.config_manager.get_timezone_offset()
+        }
+        response_body = json.dumps(config)
         response = (
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: application/json\r\n"
@@ -122,6 +145,40 @@ class AsyncWebServer:
             )
             writer.write(response.encode('utf-8'))
             await writer.drain()
+    
+    async def handle_update_config(self, request_lines, writer):
+        """Handle POST request to update configuration settings"""
+        _, body = self.parse_request_body(request_lines)
+        try:
+            params = json.loads(body)
+            applet_duration = params.get("applet_duration", 10)
+            timezone_offset = params.get("timezone_offset", 0)
+            
+            # Update the configs with settings
+            actual_duration = self.config_manager.set_applet_duration(applet_duration)
+            actual_offset = self.config_manager.set_timezone_offset(timezone_offset)
+            
+            print(f"[AsyncWebServer] Updated config: duration={actual_duration}, tz={actual_offset}")
+            response = (
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: application/json\r\n"
+                "Connection: close\r\n\r\n" +
+                json.dumps({
+                    "applet_duration": actual_duration,
+                    "timezone_offset": actual_offset
+                })
+                  
+            )
+        except Exception as e:
+            print(f"[AsyncWebServer] Error updating config: {e}")
+            response = (
+                "HTTP/1.1 400 Bad Request\r\n"
+                "Content-Type: text/plain\r\n"
+                "Connection: close\r\n\r\n"
+                "Could not update configuration"
+            )
+        writer.write(response.encode('utf-8'))
+        await writer.drain()
 
     async def handle_move_up(self, request_lines, writer):
         await self.handle_move("up", request_lines, writer)
@@ -205,6 +262,11 @@ class AsyncWebServer:
     #
     def web_page(self) -> str:
         print(f"[AsyncWebServer] IP address: {self.ip_address}")
+        
+        # Get current applet duration
+        applet_duration = self.config_manager.get_applet_duration()
+        timezone_offset = self.config_manager.get_timezone_offset()
+        
         html = f"""
     <!DOCTYPE html>
     <html lang="en">
@@ -266,6 +328,7 @@ class AsyncWebServer:
         /* Input fields */
         input[type="text"],
         input[type="password"],
+        input[type="number"],
         button {{
         width: 100%;
         padding: 10px;
@@ -298,7 +361,8 @@ class AsyncWebServer:
         }}
 
         input[type="text"],
-        input[type="password"] {{
+        input[type="password"],
+        input[type="number"] {{
             width: 100%;
         }}
         }}
@@ -361,6 +425,19 @@ class AsyncWebServer:
         <div id="applet-container">
         <!-- Applets will be dynamically rendered here -->
         </div>
+    </form>
+    
+    <h2>Configuration</h2>
+    <form id="config-form" style="max-width: 400px; margin: 0 auto; text-align: left;">
+        <label for="applet-duration" style="display: block; margin-bottom: 5px;">Applet Duration (seconds):</label>
+        <input type="number" id="applet-duration" name="applet_duration" min="3" max="60" step="1" value="{applet_duration}" required>
+        <p style="font-size: 12px; color: #ccc;">Duration must be between 3 and 60 seconds</p>
+    
+        <label for="timezone-offset" style="display: block; margin-top: 15px; margin-bottom: 5px;">Timezone Offset (hours from UTC):</label>
+        <input type="number" id="timezone-offset" name="timezone_offset" min="-12" max="14" step="1" value="{timezone_offset}" required>
+        <p style="font-size: 12px; color: #ccc;">Valid values between -12 and +14</p>
+    
+        <button type="submit" style="margin-top: 15px; width: 100%;">Save Configuration</button>
     </form>
 
     <button onclick="rebootDevice()" style="max-width: 400px; margin: 20px auto;">Reboot Device</button>
@@ -452,6 +529,22 @@ async function fetchApplets() {{
     }}
   }} catch (error) {{
     console.error('Error fetching applets:', error);
+  }}
+}}
+
+// Fetch configuration
+async function fetchConfig() {{
+  try {{
+    const response = await fetch(`http://${{serverIP}}/config`);
+    if (response.ok) {{
+      const config = await response.json();
+      document.getElementById('applet-duration').value = config.applet_duration;
+      document.getElementById('timezone-offset').value = config.timezone_offset;
+    }} else {{
+      alert('Failed to fetch configuration');
+    }}
+  }} catch (error) {{
+    console.error('Error fetching configuration:', error);
   }}
 }}
 
@@ -553,13 +646,45 @@ async function saveApplets(event) {{
   }}
 }}
 
+// Save configuration
+async function saveConfig(event) {{
+  event.preventDefault();
+  const form = document.getElementById('config-form');
+  const formData = new FormData(form);
+  const data = {{
+    applet_duration: parseInt(formData.get('applet_duration'), 10),
+    timezone_offset: parseInt(formData.get('timezone_offset'), 10)
+  }};
+  
+  try {{
+    const response = await fetch(`http://${{serverIP}}/update_config`, {{
+      method: 'POST',
+      headers: {{'Content-Type': 'application/json'}},
+      body: JSON.stringify(data),
+    }});
+    
+    if (response.ok) {{
+      const result = await response.json();
+      // Update the input field with the actual value (in case it was adjusted)
+      document.getElementById('applet-duration').value = result.applet_duration;
+      alert('Configuration saved successfully!');
+    }} else {{
+      alert('Failed to save configuration');
+    }}
+  }} catch (error) {{
+    console.error('Error saving configuration:', error);
+  }}
+}}
+
 // Attach handlers
 document.getElementById('wifi-form').addEventListener('submit', addNetwork);
 document.getElementById('applet-form').addEventListener('submit', saveApplets);
+document.getElementById('config-form').addEventListener('submit', saveConfig);
 
 // Initial fetch
 fetchNetworks();
 fetchApplets();
+fetchConfig();
     </script>
     </body>
 


### PR DESCRIPTION
I have update the Bitcoin ticker functionality to change the footer timestamp from UTC to a user configurable timezone offset. This because MicroPython doesn't seem to have support TZ type settings. 

Goal, to make footer display time like this:
Time now would be 07:22:15 UTC
- UTC still displays as 07:22:15 UTC
- UTC +2 displays as 09:22:15 UTC +2

So I have changed the following:
- main.py -> Create instance of ConfigManager to be used everywhere
- config.py -> Added functionality to save and load timezone details
- screen_manager.py -> Added logic to format footer
- web_server.py -> Added logic to be able to enter UTC offset for a user and save and retrieve it as well
 
![Screenshot from 2025-04-17 11-30-02](https://github.com/user-attachments/assets/70409ccc-a2d1-4375-b9c2-575a0fa2ed00)
