### PR TITLE
Clean version of the format footer timestamp to user preferred timezon…

### DIFF
--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -191,4 +191,3 @@ class AppletManager:
         error_applet = ErrorApplet(self.screen_manager, error_message)
         await self._run_applet(error_applet, is_system_applet=True)
         self.running = False
-

--- a/src/config.py
+++ b/src/config.py
@@ -4,14 +4,15 @@ import os
 class ConfigManager:
     """
     Manages configuration settings for the Bitcoin Ticker application.
-    Currently supports applet duration configuration.
+    Currently supports applet duration and timezone offset configuration.
     """
     
     def __init__(self):
         self.config = {}
         self.filename = "config.json"
         self.defaults = {
-            "applet_duration": 10  # Default duration in seconds
+            "applet_duration": 10,  # Default duration in seconds
+            "timezone_offset": 0     # Default timezone offset (UTC)
         }
         self.load_config()
     
@@ -54,3 +55,27 @@ class ConfigManager:
         except (ValueError, TypeError):
             # If conversion fails, return the current value
             return self.get_applet_duration()
+    
+    def get_timezone_offset(self):
+        """Get the current timezone offset from UTC in hours"""
+        return self.config.get("timezone_offset", self.defaults["timezone_offset"])
+    
+    def set_timezone_offset(self, offset):
+        """
+        Set and validate the timezone offset
+        
+        :param offset: Offset in hours from UTC (clamped between -12 and +14)
+        :return: The actual offset that was set after validation
+        """
+        try:
+            # Convert to integer and clamp between -12 and +14 hours
+            # (Valid timezone ranges from UTC-12 to UTC+14)
+            offset = int(offset)
+            offset = max(-12, min(14, offset))
+            
+            self.config["timezone_offset"] = offset
+            self.save_config()
+            return offset
+        except (ValueError, TypeError):
+            # If conversion fails, return the current value
+            return self.get_timezone_offset()

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from wifi_manager import WiFiManager
 from web_server import AsyncWebServer
 from applet_manager import AppletManager
 from system_applets import ap_applet
+from config import ConfigManager
 
 RGBLED(6, 7, 8).set_rgb(0, 0, 0)
 
@@ -18,7 +19,8 @@ async def main() -> None:
     and starts the web server. It keeps an asynchronous loop alive to service
     other tasks such as applets and data retrieval.
     """
-    screen_manager = ScreenManager()
+    config_manager = ConfigManager()
+    screen_manager = ScreenManager(config_manager=config_manager)
     data_manager = DataManager()
     wifi_manager = WiFiManager()
 


### PR DESCRIPTION
Attempt 2 of this feature with cleaned merge conflicts.

I have update the Bitcoin ticker functionality to change the footer timestamp from UTC to a user configurable timezone offset. This because MicroPython doesn't seem to have support TZ type settings. 

Goal, to make footer display time like this:
Time now would be 07:22:15 UTC
- UTC still displays as 07:22:15 UTC
- UTC +2 displays as 09:22:15 UTC +2

So I have changed the following:
- main.py -> Create instance of ConfigManager to be used everywhere
- config.py -> Added functionality to save and load timezone details
- screen_manager.py -> Added logic to format footer
- web_server.py -> Added logic to be able to enter UTC offset for a user and save and retrieve it as well
 
![Screenshot from 2025-04-17 11-30-02](https://github.com/user-attachments/assets/70409ccc-a2d1-4375-b9c2-575a0fa2ed00)
