### PR TITLE
Fix applet save and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .venv/
 .DS_Store
+.aider*

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -56,6 +56,7 @@ class AppletManager:
             for applet in applets:
                 data.append({"name": applet["name"], "enabled": applet["enabled"]})
             json.dump(data, f)
+        self.applets = self.load_applets(filename)
 
     def get_applets_list(self):
         try:
@@ -134,6 +135,7 @@ class AppletManager:
 
         if self.current_applet:
             self.current_applet.stop()
+            gc.collect()
 
         self.screen_manager.clear()
         self.current_applet = applet
@@ -169,6 +171,7 @@ class AppletManager:
         print(f"[AppletManager] Starting applet: {applet.__class__.__name__}")
         if self.current_applet:
             self.current_applet.stop()
+            gc.collect()
         try:
             self.screen_manager.clear()
             self.current_applet = applet
@@ -201,6 +204,7 @@ class AppletManager:
         print(f"[AppletManager] Exception occurred: {exception}")
         if self.current_applet:
             self.current_applet.stop()
+            gc.collect()
 
         error_message = str(exception)
         error_applet = ErrorApplet(self.screen_manager, error_message)

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -12,10 +12,11 @@ class bitcoin_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
         self.drawn = False
-        self.register()
+        #self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -12,10 +12,11 @@ class bitcoin_eur_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCEUR"
         self.drawn = False
-        self.register()
+        #self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/block_height_applet.py
+++ b/src/applets/block_height_applet.py
@@ -12,10 +12,11 @@ class block_height_applet(BaseApplet):
         self.api_url = "https://mempool.space/api/v1/blocks/tip/height"
         self.cached_data = None
         self.drawn = False
-        self.register()
+        #self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         self.cached_data = None

--- a/src/applets/difficulty_applet.py
+++ b/src/applets/difficulty_applet.py
@@ -14,10 +14,11 @@ class difficulty_applet(BaseApplet):
         self.mempool_api = "https://mempool.space/api/v1/difficulty-adjustment"
         self.blockchain_api = "https://blockchain.info/q/getdifficulty"
         self.drawn = False
-        self.register()
+        #self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/fee_applet.py
+++ b/src/applets/fee_applet.py
@@ -10,10 +10,10 @@ class fee_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/v1/fees/recommended"
         self.drawn = False
-        self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/halving_countdown_applet.py
+++ b/src/applets/halving_countdown_applet.py
@@ -16,6 +16,7 @@ class halving_countdown_applet(BaseApplet):
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/mempool_status_applet.py
+++ b/src/applets/mempool_status_applet.py
@@ -11,10 +11,11 @@ class mempool_status_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/mempool"
         self.drawn = False
-        self.register()
+        #self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()

--- a/src/applets/moscow_time_applet.py
+++ b/src/applets/moscow_time_applet.py
@@ -11,10 +11,10 @@ class moscow_time_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
         self.drawn = False
-        self.register()
 
     def start(self):
         super().start()
+        self.register()
 
     def stop(self):
         super().stop()
@@ -24,7 +24,6 @@ class moscow_time_applet(BaseApplet):
         self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
-        gc.collect()
         return await super().update()
 
     async def draw(self):

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -29,12 +29,12 @@ class AsyncWebServer:
         self.wifi_manager = wifi_manager
         self.applet_manager = applet_manager
         self.ip_address = self.wifi_manager.ip
-        
+
         # Initialize config manager
         self.config_manager = ConfigManager()
 
-        # Example: define your known applets
-        self.applets = self.applet_manager.get_applets_list()
+        # No need to cache applets here, get dynamically
+        # self.applets = self.applet_manager.get_applets_list()
         self.routes = {
             "GET /": self.handle_root,  # Serve the main HTML page
             "GET /networks": self.handle_get_networks,

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -33,8 +33,6 @@ class AsyncWebServer:
         # Initialize config manager
         self.config_manager = ConfigManager()
 
-        # No need to cache applets here, get dynamically
-        # self.applets = self.applet_manager.get_applets_list()
         self.routes = {
             "GET /": self.handle_root,  # Serve the main HTML page
             "GET /networks": self.handle_get_networks,
@@ -126,10 +124,7 @@ class AsyncWebServer:
         _, body = self.parse_request_body(request_lines)
         try:
             request= json.loads(body)
-            # update_applets handles saving the config and reloading the internal list
             self.applet_manager.update_applets(request)
-            # The line below was redundant as update_applets already reloads. Removed.
-            # self.applet_manager.applets = self.applet_manager.load_applets()
             print("[AsyncWebServer] Updated applet selection:", request)
             response = (
                 "HTTP/1.1 200 OK\r\n"

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -71,7 +71,9 @@ class AsyncWebServer:
         await writer.drain()
         
     async def handle_get_applets(self, request_lines, writer):
-        response_body = json.dumps(self.applets)
+        # Previously: used self.applets (cached during init)
+        applet_list = self.applet_manager.get_applets_list()
+        response_body = json.dumps(applet_list)
         response = (
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: application/json\r\n"
@@ -125,6 +127,7 @@ class AsyncWebServer:
         try:
             request= json.loads(body)
             self.applet_manager.update_applets(request)
+            self.applet_manager.applets = self.applet_manager.load_applets()
             print("[AsyncWebServer] Updated applet selection:", request)
             response = (
                 "HTTP/1.1 200 OK\r\n"
@@ -638,6 +641,7 @@ async function saveApplets(event) {{
     }});
     if (response.ok) {{
       alert('Applet selection saved successfully!');
+      fetchApplets();
     }} else {{
       alert('Failed to save applet selection');
     }}

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -126,8 +126,10 @@ class AsyncWebServer:
         _, body = self.parse_request_body(request_lines)
         try:
             request= json.loads(body)
+            # update_applets handles saving the config and reloading the internal list
             self.applet_manager.update_applets(request)
-            self.applet_manager.applets = self.applet_manager.load_applets()
+            # The line below was redundant as update_applets already reloads. Removed.
+            # self.applet_manager.applets = self.applet_manager.load_applets()
             print("[AsyncWebServer] Updated applet selection:", request)
             response = (
                 "HTTP/1.1 200 OK\r\n"


### PR DESCRIPTION
More fixes to support:

- The fetching and saving of selected applets
- Supporting correct display of applets in the gui
- Supporting a bit more efficient handing in the applets themselves by only initializing when selected
- Fixed counter issue in applet_manager.py where counter of displayed applets was increased twice every loop causing every 2nd applet selected to be skipped.
- Selecting applets in gui and saving them should be enough to get them shown on the Pico, no reboots needed.