### PR TITLE
Applet transitions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ To build your own Satoshi Radio Ticker, you'll need:
 ### Pro-tips
 - To access the Settings page after initial setup, simply browse to the ticker's IP address on your local network. There's no need to connect directly to the ticker.
 - You can add multiple WiFi networks! This makes it convenient to connect the ticker to both your home network and your phone's hotspot.
+- You can change settings on the Settings page related to your timezone, duration of applets on screen and some cool applet transition effects. 
 - You can fork the code and add your own customizations! After you're done, just use the makefile to upload your modified code to the Pi. See the development section below for details.
 - Need to reset the Raspberry Pi? There is a whole in the enclosure. Just use a paperclip, you can easily reach the BOOTSEL button.
 
@@ -100,6 +101,7 @@ src/
 ├── urllib_urequest.py          # HTTP client
 ├── web_server.py               # Configuration web interface
 ├── wifi_manager.py             # Network connection manager
+├── transitions.py              # Utility to help manage applet transition effects
 └── config.py                   # Utility to help manage configurations
 ```
 

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -22,10 +22,12 @@ from config import ConfigManager
 
 
 class AppletManager:
-    def __init__(self, screen_manager, data_manager, wifi_manager) -> None:
+    # Add config_manager parameter
+    def __init__(self, screen_manager, data_manager, wifi_manager, config_manager: ConfigManager) -> None:
         self.screen_manager = screen_manager
         self.data_manager = data_manager
         self.wifi_manager = wifi_manager
+        self.config_manager = config_manager # Use the passed instance
 
         self.current_applet = None
         self.current_index = 0
@@ -34,7 +36,8 @@ class AppletManager:
         self.next_applet_data = None
 
         gc.collect()
-        self.config_manager = ConfigManager()
+        # Remove instantiation here, use the passed instance
+        # self.config_manager = ConfigManager()
 
         self._register_applets()
 

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -166,6 +166,7 @@ class AppletManager:
             print(f"[AppletManager] Stopping applet: {self.current_applet.__class__.__name__}")
             # Get the *current* transition setting just before potentially running the exit transition
             selected_transition_name = self.config_manager.get_transition_effect()
+            print(f"[AppletManager] Read transition for exit: '{selected_transition_name}'") # ADDED LOGGING
             exit_transition, _ = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need exit func here
             if exit_transition:
                 print(f"[AppletManager] Running exit transition: {selected_transition_name}")
@@ -185,11 +186,13 @@ class AppletManager:
         # --- Transition In ---
         # Get the *current* transition setting just before potentially running the entry transition
         selected_transition_name = self.config_manager.get_transition_effect()
+        print(f"[AppletManager] Read transition for entry: '{selected_transition_name}'") # ADDED LOGGING
         _, entry_transition = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need entry func here
 
         if entry_transition:
             print(f"[AppletManager] Running entry transition: {selected_transition_name}")
-            if selected_transition_name == "Wipe LTR":
+            # Corrected key name from previous commit
+            if selected_transition_name == "Wipe Left-To-Right":
                  # Wipe LTR requires the applet instance to draw during the wipe
                 await entry_transition(self.screen_manager, self.current_applet)
             elif selected_transition_name == "Fade":
@@ -199,7 +202,8 @@ class AppletManager:
                 await entry_transition(self.screen_manager) # Run fade_in
             else:
                  # Handle other potential future transitions or default to just drawing
-                 print(f"[AppletManager] Unknown entry transition '{selected_transition_name}', drawing directly.")
+                 # Check against the actual key used in transitions.py
+                 print(f"[AppletManager] Unknown or unsupported entry transition '{selected_transition_name}', drawing directly.")
                  await self.current_applet.draw()
                  self.screen_manager.update()
                  self.screen_manager.display.set_backlight(1.0) # Ensure backlight is on

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -191,9 +191,9 @@ class AppletManager:
 
         if entry_transition:
             print(f"[AppletManager] Running entry transition: {selected_transition_name}")
-            # Corrected key name from previous commit
-            if selected_transition_name == "Wipe Left-To-Right":
-                 # Wipe LTR requires the applet instance to draw during the wipe
+            # Check if the transition name indicates a wipe effect requiring the applet instance
+            if "Wipe" in selected_transition_name:
+                 # All Wipe transitions require the applet instance to draw during the wipe
                 await entry_transition(self.screen_manager, self.current_applet)
             elif selected_transition_name == "Fade":
                 # Fade In draws the first frame, then fades the backlight

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -177,14 +177,25 @@ class AppletManager:
 
         # --- Transition In ---
         if entry_transition:
-            # Draw the first frame before fading in
-            await self.current_applet.update()
-            await self.current_applet.draw()
-            self.screen_manager.update() # Update display buffer
-            await entry_transition(self.screen_manager) # Run entry transition
+            # For transitions like Wipe In, we need to pass the applet instance
+            # Check function signature or use inspection if possible, but try/except is simpler here
+            try:
+                # Attempt to call with applet instance
+                await entry_transition(self.screen_manager, self.current_applet)
+            except TypeError:
+                # If it fails, call without applet instance (like fade_in)
+                # Draw the first frame first for effects like fade
+                await self.current_applet.update()
+                await self.current_applet.draw()
+                self.screen_manager.update() # Update display buffer
+                await entry_transition(self.screen_manager)
         else:
             # If no transition, ensure backlight is on (might have been turned off by fade out)
              self.screen_manager.display.set_backlight(1.0)
+             # Also ensure the applet is drawn once if no transition handles it
+             await self.current_applet.update()
+             await self.current_applet.draw()
+             self.screen_manager.update()
 
 
         applet_duration = max(3, self.config_manager.get_applet_duration())

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -159,12 +159,13 @@ class AppletManager:
         gc.collect()
 
         # --- Transition Out ---
-        selected_transition_name = self.config_manager.get_transition_effect()
-        exit_transition, entry_transition = transitions.TRANSITIONS.get(selected_transition_name, (None, None))
-
         if self.current_applet:
             print(f"[AppletManager] Stopping applet: {self.current_applet.__class__.__name__}")
+            # Get the *current* transition setting just before potentially running the exit transition
+            selected_transition_name = self.config_manager.get_transition_effect()
+            exit_transition, _ = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need exit func here
             if exit_transition:
+                print(f"[AppletManager] Running exit transition: {selected_transition_name}")
                 await exit_transition(self.screen_manager) # Run exit transition before stopping
             self.current_applet.stop()
             gc.collect()
@@ -179,6 +180,10 @@ class AppletManager:
         await self.current_applet.update()
 
         # --- Transition In ---
+        # Get the *current* transition setting just before potentially running the entry transition
+        selected_transition_name = self.config_manager.get_transition_effect()
+        _, entry_transition = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need entry func here
+
         if entry_transition:
             print(f"[AppletManager] Running entry transition: {selected_transition_name}")
             if selected_transition_name == "Wipe LTR":

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -166,7 +166,7 @@ class AppletManager:
             print(f"[AppletManager] Stopping applet: {self.current_applet.__class__.__name__}")
             # Get the *current* transition setting just before potentially running the exit transition
             selected_transition_name = self.config_manager.get_transition_effect()
-            print(f"[AppletManager] Read transition for exit: '{selected_transition_name}'") # ADDED LOGGING
+            # print(f"[AppletManager] Read transition for exit: '{selected_transition_name}'") # REMOVED LOGGING
             exit_transition, _ = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need exit func here
             if exit_transition:
                 print(f"[AppletManager] Running exit transition: {selected_transition_name}")
@@ -186,7 +186,7 @@ class AppletManager:
         # --- Transition In ---
         # Get the *current* transition setting just before potentially running the entry transition
         selected_transition_name = self.config_manager.get_transition_effect()
-        print(f"[AppletManager] Read transition for entry: '{selected_transition_name}'") # ADDED LOGGING
+        # print(f"[AppletManager] Read transition for entry: '{selected_transition_name}'") # REMOVED LOGGING
         _, entry_transition = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need entry func here
 
         if entry_transition:

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -87,13 +87,11 @@ class AppletManager:
                 data = json.load(f)
                 print(f"[AppletManager] Loaded applets from {filename}")
         except OSError:
-            print(f"[AppletManager] Failed to load applets from {filename}. Starting with defaults.")
-            data = []
-            for applet_name in self.all_applets.keys():
-                data.append({"name": applet_name, "enabled": True})
+            # Don't create defaults, just return empty on file read error
             print(f"[AppletManager] WARNING: Could not read {filename}. Returning empty applet list.")
             return []
         except ValueError:
+            # Return empty on JSON parsing error
             print(f"[AppletManager] Failed to parse JSON from {filename}. Invalid format.")
             print(f"[AppletManager] WARNING: Could not parse {filename}. Returning empty applet list.")
             return []
@@ -110,17 +108,22 @@ class AppletManager:
             if not applet_class:
                 print(f"[AppletManager] Applet not found: {applet_name}")
                 continue
-            applets.append(applet_class(self.screen_manager, self.data_manager))
+            # Instantiate the applet
+            applet_instance = applet_class(self.screen_manager, self.data_manager)
+            # Register its data requirements with the DataManager
+            applet_instance.register()
+            applets.append(applet_instance)
         return applets
 
     def _get_applet_class(self, name):
         return self.all_applets.get(name)
 
     async def start_applets(self) -> None:
-        enabled_applets = self.applets
+        # Removed redundant enabled_applets = self.applets
+        # The loop below checks self.applets directly
 
-        if not enabled_applets:
-            print("[AppletManager] No applets registered. Displaying error.")
+        if not self.applets: # Check initial state
+            print("[AppletManager] No applets registered or enabled at start. Displaying error.")
             await self._display_error("No applets registered or enabled.")
             return
 

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -11,95 +11,103 @@ class bitcoin_applet(BaseApplet):
         super().__init__('bitcoin_applet', screen_manager)
         self.data_manager = data_manager
         self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
-        self.drawn = False
+        self.current_data = None # Store data fetched in update()
         self.register()
 
     def start(self):
+        # Reset data when applet starts
+        self.current_data = None
         super().start()
 
     def stop(self):
+        # No need for drawn flag handling
         super().stop()
-        self.drawn = False
 
     def register(self):
-        self.data_manager.register_endpoint(self.api_url)
+        # Register with default TTL from BaseApplet if not specified otherwise
+        self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
+        # Fetch data in update
+        self.current_data = self.data_manager.get_cached_data(self.api_url)
+        # print(f"[bitcoin_applet] Updated data: {self.current_data}") # Optional debug
         gc.collect()
-        return await super().update()
+        # No need to call super().update()
 
     async def draw(self):
-        if self.drawn:
-            return
-
+        # Draw uses data fetched by update()
         self.screen_manager.clear()
         self.screen_manager.draw_header("Bitcoin US Dollar Price")
-        self.data = self.data_manager.get_cached_data(self.api_url)
 
-        print("Initial cached data:", self.data)
+        if self.current_data is None:
+            self.screen_manager.draw_centered_text("Loading...")
+            # No footer if no data
+        elif isinstance(self.current_data, dict):
+            # Draw timestamp from the outer cache dictionary
+            self.screen_manager.draw_footer(self.current_data.get('timestamp', None))
 
-        if self.data is None:
-            gc.collect()
-            await self.data_manager._update_cache(self.api_url)
-            self.data = self.data_manager.get_cached_data(self.api_url)
-            if self.data is None:
-                return
+            # Access the nested 'data' dictionary which holds the actual API response
+            bitcoin_data = self.current_data.get('data', {})
+            if not isinstance(bitcoin_data, dict):
+                 # Handle cases where 'data' might not be a dict (e.g., error response)
+                 print(f"[bitcoin_applet] Unexpected data format: {bitcoin_data}")
+                 self.screen_manager.draw_centered_text("Data Error")
+                 gc.collect()
+                 return # Stop drawing if data format is wrong
 
-        if isinstance(self.data, dict):
-            # Access the nested 'data' dictionary first
-            bitcoin_data = self.data.get('data', {})
-
-            # Now get the price from the nested data
             price = bitcoin_data.get('lastPrice')
             change_percent = bitcoin_data.get('priceChangePercent')
 
-            if price:
+            if price is not None and change_percent is not None:
                 try:
                     usd_price = float(price)
                     change = float(change_percent)
 
                     # Draw the label, price and change
-                    self.screen_manager.draw_centered_text("BTC/USD", scale=3, y_offset=-60)  # Label above price
-                    self.screen_manager.draw_centered_text(f"${int(usd_price):,}")  # Price with default scale=8 and thousand separator
-                    # Draw the change percentage
+                    self.screen_manager.draw_centered_text("BTC/USD", scale=3, y_offset=-60)
+                    self.screen_manager.draw_centered_text(f"${int(usd_price):,}")
+
+                    # Draw the change percentage with indicator triangle
                     change_text = f"24h change: {change:+.2f}%"
                     text_width = self.screen_manager.display.measure_text(change_text, scale=2)
                     x = (self.screen_manager.width - text_width) // 2
-                    y = (self.screen_manager.height - 16) // 2 + 60  # 16 is text height at scale 2
+                    y = (self.screen_manager.height - 16) // 2 + 60 # 16 = text height scale 2
 
-                    # Draw triangle before the text
                     triangle_size = 10
-                    triangle_x = x - triangle_size - 5  # 5 pixels gap
-                    triangle_y = y + 8  # Center vertically with text
+                    triangle_x = x - triangle_size - 5
+                    triangle_y = y + 8 # Approx vertical center
 
-                    # Set color based on change direction
-                    triangle_color = self.screen_manager.theme["POSITIVE_COLOR"] if change >= 0 else self.screen_manager.theme["NEGATIVE_COLOR"]
+                    triangle_color_name = "POSITIVE_COLOR" if change >= 0 else "NEGATIVE_COLOR"
+                    triangle_color = self.screen_manager.theme[triangle_color_name]
                     self.screen_manager.display.set_pen(self.screen_manager.get_pen(triangle_color))
 
-                    if change >= 0:
-                        # Upward triangle
+                    if change >= 0: # Upward triangle
                         self.screen_manager.display.triangle(
                             triangle_x, triangle_y,
                             triangle_x + triangle_size, triangle_y,
                             triangle_x + (triangle_size // 2), triangle_y - triangle_size
                         )
-                    else:
-                        # Downward triangle
+                    else: # Downward triangle
                         self.screen_manager.display.triangle(
                             triangle_x, triangle_y - triangle_size,
                             triangle_x + triangle_size, triangle_y - triangle_size,
                             triangle_x + (triangle_size // 2), triangle_y
                         )
 
-                    # Draw the text
+                    # Draw the text (use default color)
                     self.screen_manager.draw_text(change_text, x, y, scale=2)
-                except ValueError as e:
-                    print("Error converting values:", e)
 
-        # Draw the timestamp from the outer dictionary
-        self.screen_manager.draw_footer(self.data.get('timestamp', None))
+                except (ValueError, TypeError) as e:
+                    print(f"[bitcoin_applet] Error converting values: {e}")
+                    self.screen_manager.draw_centered_text("Data Error")
+            else:
+                # Handle missing price or change data
+                self.screen_manager.draw_centered_text("N/A")
+        else:
+            # Handle case where self.current_data is not a dict (unexpected)
+            self.screen_manager.draw_centered_text("Error")
+            print(f"[bitcoin_applet] Unexpected data type: {type(self.current_data)}")
 
-        self.data = None
-        self.screen_manager.update()
-        self.drawn = True
+        # screen_manager.update() is called by AppletManager or transition
+        # self.drawn flag removed
         gc.collect()

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -11,95 +11,100 @@ class bitcoin_eur_applet(BaseApplet):
         super().__init__('bitcoin_eur_applet', screen_manager)
         self.data_manager = data_manager
         self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCEUR"
-        self.drawn = False
+        self.current_data = None # Store data fetched in update()
         self.register()
 
     def start(self):
+        # Reset data when applet starts
+        self.current_data = None
         super().start()
 
     def stop(self):
+        # No need for drawn flag handling
         super().stop()
-        self.drawn = False
 
     def register(self):
-        self.data_manager.register_endpoint(self.api_url)
+        # Register with default TTL from BaseApplet if not specified otherwise
+        self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
+        # Fetch data in update
+        self.current_data = self.data_manager.get_cached_data(self.api_url)
+        # print(f"[bitcoin_eur_applet] Updated data: {self.current_data}") # Optional debug
         gc.collect()
-        return await super().update()
+        # No need to call super().update()
 
     async def draw(self):
-        if self.drawn:
-            return
-
+        # Draw uses data fetched by update()
         self.screen_manager.clear()
         self.screen_manager.draw_header("Bitcoin Euro Price")
-        self.data = self.data_manager.get_cached_data(self.api_url)
 
-        print("Initial cached data:", self.data)
+        if self.current_data is None:
+            self.screen_manager.draw_centered_text("Loading...")
+            # No footer if no data
+        elif isinstance(self.current_data, dict):
+            # Draw timestamp from the outer cache dictionary
+            self.screen_manager.draw_footer(self.current_data.get('timestamp', None))
 
-        if self.data is None:
-            gc.collect()
-            await self.data_manager._update_cache(self.api_url)
-            self.data = self.data_manager.get_cached_data(self.api_url)
-            if self.data is None:
-                return
+            # Access the nested 'data' dictionary which holds the actual API response
+            bitcoin_data = self.current_data.get('data', {})
+            if not isinstance(bitcoin_data, dict):
+                 print(f"[bitcoin_eur_applet] Unexpected data format: {bitcoin_data}")
+                 self.screen_manager.draw_centered_text("Data Error")
+                 gc.collect()
+                 return
 
-        if isinstance(self.data, dict):
-            # Access the nested 'data' dictionary first
-            bitcoin_data = self.data.get('data', {})
-
-            # Now get the price from the nested data
             price = bitcoin_data.get('lastPrice')
             change_percent = bitcoin_data.get('priceChangePercent')
 
-            if price:
+            if price is not None and change_percent is not None:
                 try:
                     eur_price = float(price)
                     change = float(change_percent)
 
                     # Draw the label, price and change
-                    self.screen_manager.draw_centered_text("BTC/EUR", scale=3, y_offset=-60)  # Label above price
-                    self.screen_manager.draw_centered_text(f"E{int(eur_price):,}")  # Price with default scale=8 and thousand separator
-                    # Draw the change percentage
+                    self.screen_manager.draw_centered_text("BTC/EUR", scale=3, y_offset=-60)
+                    self.screen_manager.draw_centered_text(f"€{int(eur_price):,}") # Use Euro symbol
+
+                    # Draw the change percentage with indicator triangle
                     change_text = f"24h change: {change:+.2f}%"
                     text_width = self.screen_manager.display.measure_text(change_text, scale=2)
                     x = (self.screen_manager.width - text_width) // 2
-                    y = (self.screen_manager.height - 16) // 2 + 60  # 16 is text height at scale 2
+                    y = (self.screen_manager.height - 16) // 2 + 60 # 16 = text height scale 2
 
-                    # Draw triangle before the text
                     triangle_size = 10
-                    triangle_x = x - triangle_size - 5  # 5 pixels gap
-                    triangle_y = y + 8  # Center vertically with text
+                    triangle_x = x - triangle_size - 5
+                    triangle_y = y + 8 # Approx vertical center
 
-                    # Set color based on change direction
-                    triangle_color = self.screen_manager.theme["POSITIVE_COLOR"] if change >= 0 else self.screen_manager.theme["NEGATIVE_COLOR"]
+                    triangle_color_name = "POSITIVE_COLOR" if change >= 0 else "NEGATIVE_COLOR"
+                    triangle_color = self.screen_manager.theme[triangle_color_name]
                     self.screen_manager.display.set_pen(self.screen_manager.get_pen(triangle_color))
 
-                    if change >= 0:
-                        # Upward triangle
+                    if change >= 0: # Upward triangle
                         self.screen_manager.display.triangle(
                             triangle_x, triangle_y,
                             triangle_x + triangle_size, triangle_y,
                             triangle_x + (triangle_size // 2), triangle_y - triangle_size
                         )
-                    else:
-                        # Downward triangle
+                    else: # Downward triangle
                         self.screen_manager.display.triangle(
                             triangle_x, triangle_y - triangle_size,
                             triangle_x + triangle_size, triangle_y - triangle_size,
                             triangle_x + (triangle_size // 2), triangle_y
                         )
 
-                    # Draw the text
+                    # Draw the text (use default color)
                     self.screen_manager.draw_text(change_text, x, y, scale=2)
-                except ValueError as e:
-                    print("Error converting values:", e)
 
-        # Draw the timestamp from the outer dictionary
-        self.screen_manager.draw_footer(self.data.get('timestamp', None))
+                except (ValueError, TypeError) as e:
+                    print(f"[bitcoin_eur_applet] Error converting values: {e}")
+                    self.screen_manager.draw_centered_text("Data Error")
+            else:
+                self.screen_manager.draw_centered_text("N/A") # Handle missing data
+        else:
+            self.screen_manager.draw_centered_text("Error") # Handle unexpected data type
+            print(f"[bitcoin_eur_applet] Unexpected data type: {type(self.current_data)}")
 
-        self.data = None
-        self.screen_manager.update()
-        self.drawn = True
+        # screen_manager.update() is called by AppletManager or transition
+        # self.drawn flag removed
         gc.collect()

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -64,8 +64,8 @@ class bitcoin_eur_applet(BaseApplet):
 
                     # Draw the label, price and change
                     self.screen_manager.draw_centered_text("BTC/EUR", scale=3, y_offset=-60)
-                    # Use "E " instead of Euro symbol for compatibility with bitmap font
-                    self.screen_manager.draw_centered_text(f"E {int(eur_price):,}")
+                    # Use "E" without space for bitmap font compatibility
+                    self.screen_manager.draw_centered_text(f"E{int(eur_price):,}")
 
                     # Draw the change percentage with indicator triangle
                     change_text = f"24h change: {change:+.2f}%"

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -64,7 +64,8 @@ class bitcoin_eur_applet(BaseApplet):
 
                     # Draw the label, price and change
                     self.screen_manager.draw_centered_text("BTC/EUR", scale=3, y_offset=-60)
-                    self.screen_manager.draw_centered_text(f"€{int(eur_price):,}") # Use Euro symbol
+                    # Use "E " instead of Euro symbol for compatibility with bitmap font
+                    self.screen_manager.draw_centered_text(f"E {int(eur_price):,}")
 
                     # Draw the change percentage with indicator triangle
                     change_text = f"24h change: {change:+.2f}%"

--- a/src/applets/difficulty_applet.py
+++ b/src/applets/difficulty_applet.py
@@ -13,22 +13,30 @@ class difficulty_applet(BaseApplet):
         self.data_manager = data_manager
         self.mempool_api = "https://mempool.space/api/v1/difficulty-adjustment"
         self.blockchain_api = "https://blockchain.info/q/getdifficulty"
-        self.drawn = False
+        self.mempool_data = None # Store data for mempool API
+        self.difficulty_data = None # Store data for blockchain API
         self.register()
 
     def start(self):
+        # Reset data when applet starts
+        self.mempool_data = None
+        self.difficulty_data = None
         super().start()
 
     def stop(self):
+        # No need for drawn flag handling
         super().stop()
-        self.drawn = False
 
     def register(self):
         self.data_manager.register_endpoint(self.mempool_api, self.TTL)
         self.data_manager.register_endpoint(self.blockchain_api, self.TTL)
 
     async def update(self):
-        return await super().update()
+        # Fetch data for both endpoints
+        self.mempool_data = self.data_manager.get_cached_data(self.mempool_api)
+        self.difficulty_data = self.data_manager.get_cached_data(self.blockchain_api)
+        gc.collect()
+        # No need to call super().update()
 
     def draw_kv(self, label: str, value: str, y: int):
         """Draw a label left-aligned and a value right-aligned."""
@@ -38,33 +46,30 @@ class difficulty_applet(BaseApplet):
             self.screen_manager.width - 10 - text_width, y, scale=2)
 
     async def draw(self):
-        if self.drawn:
-            return
-
+        # Draw uses data fetched by update()
         self.screen_manager.clear()
         self.screen_manager.draw_header("Bitcoin Difficulty Stats")
 
-        mempool_data = self.data_manager.get_cached_data(self.mempool_api)
-        difficulty_data = self.data_manager.get_cached_data(self.blockchain_api)
-
-        if mempool_data is None or difficulty_data is None:
+        # Use the data fetched in update()
+        if self.mempool_data is None or self.difficulty_data is None:
+            self.screen_manager.draw_centered_text("Loading...")
+            # No footer if no data
             gc.collect()
-            await self.data_manager._update_cache(self.mempool_api)
-            await self.data_manager._update_cache(self.blockchain_api)
-            mempool_data = self.data_manager.get_cached_data(self.mempool_api)
-            difficulty_data = self.data_manager.get_cached_data(self.blockchain_api)
-            if mempool_data is None or difficulty_data is None:
-                return
+            return
 
-        self.screen_manager.draw_footer(mempool_data.get('timestamp', None))
-        raw = mempool_data.get("data", {})
-        y = 40  # Room for 5 rows
+        # Use mempool data timestamp for footer as it's more detailed
+        self.screen_manager.draw_footer(self.mempool_data.get('timestamp', None))
+
+        # Extract nested data dictionaries
+        mempool_raw = self.mempool_data.get("data", {})
+        difficulty_raw_str = self.difficulty_data.get("data", "0") # blockchain.info just returns the number
+
+        y = 40  # Starting Y position for drawing key-value pairs
 
         # 1. Current difficulty from blockchain.info
         try:
-            raw_diff_str = difficulty_data.get("data", "0")
-            difficulty = float(raw_diff_str)
-            if difficulty >= 1e12:
+            difficulty = float(difficulty_raw_str)
+            if difficulty >= 1e12: # Format as Trillions if large enough
                 difficulty_str = f"{difficulty / 1e12:.1f}T"
             else:
                 difficulty_str = f"{difficulty:.0f}"
@@ -73,48 +78,52 @@ class difficulty_applet(BaseApplet):
         self.draw_kv("Current diff:", difficulty_str, y)
         y += 26
 
-        # 2. Progress %
+        # 2. Progress % (from mempool data)
         try:
-            progress = raw.get("progressPercent")
+            progress = mempool_raw.get("progressPercent")
             progress_str = f"{progress:.1f}%" if progress is not None else "N/A"
-        except Exception:
-            progress_str = "N/A"
+        except (ValueError, TypeError):
+            progress_str = "Error"
         self.draw_kv("Progress:", progress_str, y)
         y += 26
 
-        # 3. Estimated Retarget Date
+        # 3. Estimated Retarget Date (from mempool data)
         try:
-            ms_ts = int(raw.get("estimatedRetargetDate", 0))
-            if ms_ts > 0:
-                ts = ms_ts // 1000
-                t = time.localtime(ts)
+            ms_ts = mempool_raw.get("estimatedRetargetDate")
+            if ms_ts is not None:
+                # Convert ms timestamp to seconds for time.localtime
+                ts = int(ms_ts) // 1000
+                # Apply timezone offset from config manager if needed (assuming localtime uses system time)
+                # Note: Pico might not have full timezone support in time module.
+                # offset_seconds = self.screen_manager.config_manager.get_timezone_offset() * 3600
+                # t = time.localtime(ts + offset_seconds)
+                t = time.localtime(ts) # Using device local time for now
                 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
                 formatted_date = f"{t[2]:02d} {months[t[1] - 1]} {t[3]:02d}:{t[4]:02d}"
             else:
                 formatted_date = "N/A"
-        except Exception:
-            formatted_date = "N/A"
+        except (ValueError, TypeError, AttributeError):
+            formatted_date = "Error"
         self.draw_kv("Retarget:", formatted_date, y)
         y += 26
 
-        # 4. Blocks remaining
+        # 4. Blocks remaining (from mempool data)
         try:
-            blocks_remaining = raw.get("remainingBlocks")
-            blocks_str = str(blocks_remaining) if blocks_remaining is not None else "N/A"
-        except Exception:
-            blocks_str = "N/A"
+            blocks_remaining = mempool_raw.get("remainingBlocks")
+            blocks_str = f"{blocks_remaining:,}" if blocks_remaining is not None else "N/A"
+        except (ValueError, TypeError):
+            blocks_str = "Error"
         self.draw_kv("Blocks left:", blocks_str, y)
         y += 26
 
-        # 5. Expected new difficulty
+        # 5. Expected new difficulty (calculated using both data sources)
         try:
-            diff_change = raw.get("difficultyChange")
-            if diff_change is not None and difficulty_str != "N/A":
-                # Calculate expected new difficulty
-                current_diff = float(raw_diff_str)
-                new_diff = current_diff * (1 + diff_change / 100)
-        
+            diff_change = mempool_raw.get("difficultyChange")
+            if diff_change is not None and difficulty_str not in ["N/A", "Error"]:
+                current_diff = float(difficulty_raw_str) # Use the raw string from blockchain.info
+                new_diff = current_diff * (1 + (float(diff_change) / 100.0))
+
                 # Format similarly to current difficulty
                 if new_diff >= 1e12:
                     new_diff_str = f"{new_diff / 1e12:.1f}T"
@@ -122,11 +131,11 @@ class difficulty_applet(BaseApplet):
                     new_diff_str = f"{new_diff:.0f}"
             else:
                 new_diff_str = "N/A"
-        except Exception:
-            new_diff_str = "N/A"
+        except (ValueError, TypeError):
+             new_diff_str = "Error" # Handle potential float conversion errors
         self.draw_kv("Expected diff:", new_diff_str, y)
         y += 26
 
-        self.screen_manager.update()
-        self.drawn = True
+        # screen_manager.update() is called by AppletManager or transition
+        # self.drawn flag removed
         gc.collect()

--- a/src/applets/fee_applet.py
+++ b/src/applets/fee_applet.py
@@ -9,49 +9,64 @@ class fee_applet(BaseApplet):
         super().__init__('fee_applet', screen_manager)
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/v1/fees/recommended"
-        self.drawn = False
+        self.current_data = None # Store data fetched in update()
         self.register()
 
     def start(self):
+        # Reset data when applet starts
+        self.current_data = None
         super().start()
 
     def stop(self):
+        # No need for drawn flag handling
         super().stop()
-        self.drawn = False
 
     def register(self):
         self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
-        return await super().update()
+        # Fetch data in update
+        self.current_data = self.data_manager.get_cached_data(self.api_url)
+        gc.collect()
+        # No need to call super().update()
 
     async def draw(self):
-        if self.drawn:
-            return
+        # Draw uses data fetched by update()
         self.screen_manager.clear()
         self.screen_manager.draw_header("Bitcoin Mempool Fees")
 
-        self.data = self.data_manager.get_cached_data(self.api_url)
-        if self.data is None:
-            print("No data")
+        if self.current_data is None:
+            self.screen_manager.draw_centered_text("Loading...")
+            # No footer if no data
             gc.collect()
-            await self.data_manager._update_cache(self.api_url)
-            self.data = self.data_manager.get_cached_data(self.api_url)
-            if self.data is None:
-                return
+            return
 
-        self.screen_manager.draw_footer(self.data.get('timestamp',None))
-        self.data = self.data.get('data')
-        y = 60
+        # Draw timestamp from the outer cache dictionary
+        self.screen_manager.draw_footer(self.current_data.get('timestamp', None))
+
+        # Access the nested 'data' dictionary which holds the actual API response
+        fee_data = self.current_data.get('data', {})
+        if not isinstance(fee_data, dict):
+            print(f"[fee_applet] Unexpected data format: {fee_data}")
+            self.screen_manager.draw_centered_text("Data Error")
+            gc.collect()
+            return
+
+        y = 60 # Starting Y position for fee lines
         for fee_type, fee_key in [
-            ("Fast", 'fastestFee'),
-            ("Medium", 'halfHourFee'),
-            ("Slow", 'hourFee')
+            ("Fast:", 'fastestFee'), # Added colon for consistency
+            ("Medium:", 'halfHourFee'),
+            ("Slow:", 'hourFee')
         ]:
-            fee = self.data.get(fee_key, 'N/A')
-            self.screen_manager.draw_text(f"{fee_type}:", 10, y, scale=2)
-            fee_text = f"{fee} sat/vB" if isinstance(fee, (int, float)) else str(fee)
-            self.screen_manager.draw_text(fee_text, self.screen_manager.width - 10 - self.screen_manager.display.measure_text(fee_text, 2), y, scale=2)
-            y += 40
-        self.screen_manager.update()
-        self.drawn = True
+            fee = fee_data.get(fee_key) # Get fee from nested data
+            fee_text = f"{fee} sat/vB" if isinstance(fee, (int, float)) else "N/A"
+
+            # Draw label left-aligned
+            self.screen_manager.draw_text(fee_type, 10, y, scale=2)
+            # Draw value right-aligned
+            value_width = self.screen_manager.display.measure_text(fee_text, scale=2)
+            self.screen_manager.draw_text(fee_text, self.screen_manager.width - 10 - value_width, y, scale=2)
+            y += 40 # Move to next line
+
+        # screen_manager.update() is called by AppletManager or transition
+        # self.drawn flag removed

--- a/src/applets/mempool_status_applet.py
+++ b/src/applets/mempool_status_applet.py
@@ -11,7 +11,7 @@ class mempool_status_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/mempool"
         self.current_data = None # Store data fetched in update()
-        self.previous_vsize = None # Store vsize from the previous update
+        # self.previous_vsize removed
         self.register()
 
     def start(self):
@@ -27,13 +27,6 @@ class mempool_status_applet(BaseApplet):
         self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
-        # Store previous vsize if current_data exists
-        if self.current_data and isinstance(self.current_data.get('data'), dict):
-            try:
-                self.previous_vsize = int(self.current_data['data'].get("vsize", 0))
-            except (ValueError, TypeError):
-                self.previous_vsize = None # Reset if previous data was bad
-
         # Fetch new data
         self.current_data = self.data_manager.get_cached_data(self.api_url)
         gc.collect()
@@ -69,68 +62,26 @@ class mempool_status_applet(BaseApplet):
             size_str = f"{size_mb:.2f} MB"
             tx_count_str = f"{count:,} TXs"
 
-            # --- Removed Traffic Light ---
-            # if size_mb < 2.0:
-            #     congestion_level = "low"
-            # elif size_mb < 10.0:
-            #     congestion_level = "medium"
-            # else:
-            #     congestion_level = "high"
-            # self.screen_manager.draw_traffic_light(congestion_level)
+            # --- Restore Traffic Light ---
+            if size_mb < 2.0:
+                congestion_level = "low"
+            elif size_mb < 10.0:
+                congestion_level = "medium"
+            else:
+                congestion_level = "high"
+            self.screen_manager.draw_traffic_light(congestion_level)
 
             # --- Draw Main Size ---
-            # Removed small header text
-            # self.screen_manager.draw_horizontal_centered_text("Mempool Size (MB)", y=60, scale=2)
-            self.screen_manager.draw_centered_text(size_str, scale=6, y_offset=-10) # Shifted up slightly
+            # Restore small header text
+            self.screen_manager.draw_horizontal_centered_text("Mempool Size (MB)", y=60, scale=2)
+            # Restore original position
+            self.screen_manager.draw_centered_text(size_str, scale=6, y_offset=0)
 
-            # --- Draw Change Indicator ---
-            change_text = "Change: N/A"
-            change_percent = 0.0
-            valid_change = False
-            if self.previous_vsize is not None and self.previous_vsize > 0:
-                try:
-                    change_percent = ((vsize - self.previous_vsize) / self.previous_vsize) * 100.0
-                    change_text = f"Change: {change_percent:+.1f}%"
-                    valid_change = True
-                except Exception as e_calc:
-                    print(f"[mempool_status_applet] Error calculating change: {e_calc}")
-                    change_text = "Change: Error"
-
-            # Calculate position for change text (below main size)
-            text_width = self.screen_manager.display.measure_text(change_text, scale=2)
-            x = (self.screen_manager.width - text_width) // 2
-            y = (self.screen_manager.height // 2) + 20 # Position below center
-
-            if valid_change:
-                # Draw triangle indicator if change is valid
-                triangle_size = 10
-                triangle_x = x - triangle_size - 5
-                triangle_y = y + 8 # Approx vertical center
-
-                # Increase is "bad" (red up arrow), Decrease is "good" (green down arrow)
-                triangle_color_name = "NEGATIVE_COLOR" if change_percent >= 0 else "POSITIVE_COLOR"
-                triangle_color = self.screen_manager.theme[triangle_color_name]
-                self.screen_manager.display.set_pen(self.screen_manager.get_pen(triangle_color))
-
-                if change_percent >= 0: # Upward triangle (Red)
-                    self.screen_manager.display.triangle(
-                        triangle_x, triangle_y,
-                        triangle_x + triangle_size, triangle_y,
-                        triangle_x + (triangle_size // 2), triangle_y - triangle_size
-                    )
-                else: # Downward triangle (Green)
-                    self.screen_manager.display.triangle(
-                        triangle_x, triangle_y - triangle_size,
-                        triangle_x + triangle_size, triangle_y - triangle_size,
-                        triangle_x + (triangle_size // 2), triangle_y
-                    )
-
-            # Draw the change text
-            self.screen_manager.draw_text(change_text, x, y, scale=2)
+            # --- Removed Change Indicator ---
 
             # --- Draw Transaction Count ---
-            # Positioned further down
-            self.screen_manager.draw_horizontal_centered_text(tx_count_str, y=self.screen_manager.height - 40, scale=2)
+            # Restore original position
+            self.screen_manager.draw_horizontal_centered_text(tx_count_str, y=self.screen_manager.height - 60, scale=2)
 
         except (ValueError, TypeError, KeyError) as e:
             print(f"[mempool_status_applet] Error parsing data: {e}")

--- a/src/applets/mempool_status_applet.py
+++ b/src/applets/mempool_status_applet.py
@@ -11,6 +11,7 @@ class mempool_status_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/mempool"
         self.current_data = None # Store data fetched in update()
+        self.previous_vsize = None # Store vsize from the previous update
         self.register()
 
     def start(self):
@@ -26,7 +27,14 @@ class mempool_status_applet(BaseApplet):
         self.data_manager.register_endpoint(self.api_url, self.TTL)
 
     async def update(self):
-        # Fetch data in update
+        # Store previous vsize if current_data exists
+        if self.current_data and isinstance(self.current_data.get('data'), dict):
+            try:
+                self.previous_vsize = int(self.current_data['data'].get("vsize", 0))
+            except (ValueError, TypeError):
+                self.previous_vsize = None # Reset if previous data was bad
+
+        # Fetch new data
         self.current_data = self.data_manager.get_cached_data(self.api_url)
         gc.collect()
         # No need to call super().update()
@@ -61,24 +69,68 @@ class mempool_status_applet(BaseApplet):
             size_str = f"{size_mb:.2f} MB"
             tx_count_str = f"{count:,} TXs"
 
-            # Congestion traffic light
-            if size_mb < 2.0:
-                congestion_level = "low"
-            elif size_mb < 10.0:
-                congestion_level = "medium"
-            else:
-                congestion_level = "high"
+            # --- Removed Traffic Light ---
+            # if size_mb < 2.0:
+            #     congestion_level = "low"
+            # elif size_mb < 10.0:
+            #     congestion_level = "medium"
+            # else:
+            #     congestion_level = "high"
+            # self.screen_manager.draw_traffic_light(congestion_level)
 
-            self.screen_manager.draw_traffic_light(congestion_level)
+            # --- Draw Main Size ---
+            # Removed small header text
+            # self.screen_manager.draw_horizontal_centered_text("Mempool Size (MB)", y=60, scale=2)
+            self.screen_manager.draw_centered_text(size_str, scale=6, y_offset=-10) # Shifted up slightly
 
-            # Draw small header
-            self.screen_manager.draw_horizontal_centered_text("Mempool Size (MB)", y=60, scale=2)
+            # --- Draw Change Indicator ---
+            change_text = "Change: N/A"
+            change_percent = 0.0
+            valid_change = False
+            if self.previous_vsize is not None and self.previous_vsize > 0:
+                try:
+                    change_percent = ((vsize - self.previous_vsize) / self.previous_vsize) * 100.0
+                    change_text = f"Change: {change_percent:+.1f}%"
+                    valid_change = True
+                except Exception as e_calc:
+                    print(f"[mempool_status_applet] Error calculating change: {e_calc}")
+                    change_text = "Change: Error"
 
-            # Draw large MB size
-            self.screen_manager.draw_centered_text(size_str, scale=6, y_offset=0)
+            # Calculate position for change text (below main size)
+            text_width = self.screen_manager.display.measure_text(change_text, scale=2)
+            x = (self.screen_manager.width - text_width) // 2
+            y = (self.screen_manager.height // 2) + 20 # Position below center
 
-            # Draw transaction count underneath
-            self.screen_manager.draw_horizontal_centered_text(tx_count_str, y=self.screen_manager.height - 60, scale=2)
+            if valid_change:
+                # Draw triangle indicator if change is valid
+                triangle_size = 10
+                triangle_x = x - triangle_size - 5
+                triangle_y = y + 8 # Approx vertical center
+
+                # Increase is "bad" (red up arrow), Decrease is "good" (green down arrow)
+                triangle_color_name = "NEGATIVE_COLOR" if change_percent >= 0 else "POSITIVE_COLOR"
+                triangle_color = self.screen_manager.theme[triangle_color_name]
+                self.screen_manager.display.set_pen(self.screen_manager.get_pen(triangle_color))
+
+                if change_percent >= 0: # Upward triangle (Red)
+                    self.screen_manager.display.triangle(
+                        triangle_x, triangle_y,
+                        triangle_x + triangle_size, triangle_y,
+                        triangle_x + (triangle_size // 2), triangle_y - triangle_size
+                    )
+                else: # Downward triangle (Green)
+                    self.screen_manager.display.triangle(
+                        triangle_x, triangle_y - triangle_size,
+                        triangle_x + triangle_size, triangle_y - triangle_size,
+                        triangle_x + (triangle_size // 2), triangle_y
+                    )
+
+            # Draw the change text
+            self.screen_manager.draw_text(change_text, x, y, scale=2)
+
+            # --- Draw Transaction Count ---
+            # Positioned further down
+            self.screen_manager.draw_horizontal_centered_text(tx_count_str, y=self.screen_manager.height - 40, scale=2)
 
         except (ValueError, TypeError, KeyError) as e:
             print(f"[mempool_status_applet] Error parsing data: {e}")

--- a/src/config.py
+++ b/src/config.py
@@ -11,11 +11,12 @@ class ConfigManager:
         self.config = {}
         self.filename = "config.json"
         self.defaults = {
-            "applet_duration": 10,  # Default duration in seconds
-            "timezone_offset": 0     # Default timezone offset (UTC)
+            "applet_duration": 10,      # Default duration in seconds
+            "timezone_offset": 0,       # Default timezone offset (UTC)
+            "transition_effect": "None" # Default transition effect
         }
         self.load_config()
-    
+
     def load_config(self):
         """Load configuration from file or create with defaults if it doesn't exist"""
         try:
@@ -79,3 +80,32 @@ class ConfigManager:
         except (ValueError, TypeError):
             # If conversion fails, return the current value
             return self.get_timezone_offset()
+
+    def get_transition_effect(self):
+        """Get the current transition effect name"""
+        # Import locally to avoid circular dependency if transitions need config
+        from transitions import AVAILABLE_TRANSITIONS
+        effect = self.config.get("transition_effect", self.defaults["transition_effect"])
+        # Ensure the stored effect is still valid
+        if effect not in AVAILABLE_TRANSITIONS:
+            print(f"[ConfigManager] Invalid transition '{effect}' found. Reverting to default.")
+            return self.defaults["transition_effect"]
+        return effect
+
+    def set_transition_effect(self, effect_name):
+        """
+        Set and validate the transition effect.
+
+        :param effect_name: The name of the transition effect (e.g., "None", "Fade")
+        :return: The actual effect name that was set after validation
+        """
+        # Import locally to avoid circular dependency
+        from transitions import AVAILABLE_TRANSITIONS
+        if effect_name in AVAILABLE_TRANSITIONS:
+            self.config["transition_effect"] = effect_name
+            self.save_config()
+            return effect_name
+        else:
+            print(f"[ConfigManager] Invalid transition effect '{effect_name}'. Not saving.")
+            # Return the current valid value instead of saving an invalid one
+            return self.get_transition_effect()

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,8 @@ async def main() -> None:
     data_manager = DataManager()
     wifi_manager = WiFiManager()
 
-    applet_manager_instance = AppletManager(screen_manager, data_manager, wifi_manager)
+    # Pass the single config_manager instance
+    applet_manager_instance = AppletManager(screen_manager, data_manager, wifi_manager, config_manager)
     splash_applet = applet_manager.SplashApplet(screen_manager)
     print("[Main] Starting splash applet.")
     await applet_manager_instance.run_applet_once(splash_applet)

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,8 @@ async def main() -> None:
         ap_mode_applet = ap_applet.ApApplet(screen_manager, wifi_manager)
         asyncio.create_task(applet_manager_instance._run_applet(ap_mode_applet, is_system_applet=True))
 
-    web_server = AsyncWebServer(wifi_manager, applet_manager_instance)
+    # Pass the single config_manager instance to the web server
+    web_server = AsyncWebServer(wifi_manager, applet_manager_instance, config_manager)
     asyncio.create_task(web_server.start_web_server())
 
     # Keep the main event loop alive

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -25,21 +25,32 @@ async def _fade(screen_manager, start_brightness, end_brightness, duration_ms):
 async def fade_out(screen_manager, duration_ms=DEFAULT_FADE_DURATION_MS):
     """Fade the screen backlight out (to black)."""
     print("[Transition] Fading out...")
-    current_brightness = screen_manager.display.get_backlight() # Assuming get_backlight() exists or use a default like 1.0
-    # Pimoroni library might not have get_backlight, assume it starts at 1.0 if unavailable
-    # For now, let's assume it fades from 1.0
-    await _fade(screen_manager, 1.0, 0.0, duration_ms)
-    print("[Transition] Fade out complete.")
+    try:
+        # Ensure backlight is fully on before starting fade out
+        screen_manager.display.set_backlight(1.0)
+        await asyncio.sleep_ms(20) # Small delay to ensure it takes effect
+        # Fade from 1.0 to 0.0
+        await _fade(screen_manager, 1.0, 0.0, duration_ms)
+        print("[Transition] Fade out complete.")
+    except Exception as e:
+        print(f"[Transition] Error during fade out: {e}")
+        # Ensure backlight is off in case of error during fade
+        screen_manager.display.set_backlight(0.0)
 
 
 async def fade_in(screen_manager, duration_ms=DEFAULT_FADE_DURATION_MS):
     """Fade the screen backlight in (from black)."""
     print("[Transition] Fading in...")
-    # Ensure screen starts black before fading in
-    screen_manager.display.set_backlight(0.0)
-    await asyncio.sleep_ms(50) # Small delay to ensure backlight is off
-    await _fade(screen_manager, 0.0, 1.0, duration_ms)
-    print("[Transition] Fade in complete.")
+    try:
+        # Ensure screen starts black before fading in
+        screen_manager.display.set_backlight(0.0)
+        await asyncio.sleep_ms(50) # Small delay to ensure backlight is off
+        await _fade(screen_manager, 0.0, 1.0, duration_ms)
+        print("[Transition] Fade in complete.")
+    except Exception as e:
+        print(f"[Transition] Error during fade in: {e}")
+        # Ensure backlight is on in case of error during fade
+        screen_manager.display.set_backlight(1.0)
 
 
 # Dictionary mapping transition names to their functions (or None)

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -332,5 +332,12 @@ TRANSITIONS = {
     # Add more transitions here in the future
 }
 
-# List of available transition names for the UI
-AVAILABLE_TRANSITIONS = list(TRANSITIONS.keys())
+# List of available transition names for the UI, in the desired order
+AVAILABLE_TRANSITIONS = [
+    "None",
+    "Fade",
+    "Wipe Left-To-Right",
+    "Wipe Right-To-Left",
+    "Wipe Top-To-Bottom",
+    "Wipe Bottom-To-Top",
+]

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -124,8 +124,13 @@ async def wipe_in_from_black_ltr(screen_manager, applet_to_draw, duration_ms=DEF
         print(f"[Transition] Error during wipe in LTR: {e}")
         # Ensure full applet is drawn in case of error
         display.remove_clip() # Ensure clip is removed
+        # Perform a final, unclipped draw to ensure the full screen is correct
         await applet_to_draw.draw()
         display.update()
+    finally:
+        # Ensure clip is always removed, even if errors occurred above
+        # Using screen_manager instance as 'display' might not be defined if error happened early
+        screen_manager.display.remove_clip()
 
 
 # Dictionary mapping transition names to their functions (or None)

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -139,7 +139,7 @@ async def wipe_in_from_black_ltr(screen_manager, applet_to_draw, duration_ms=DEF
 TRANSITIONS = {
     "None": (None, None),
     "Fade": (fade_out, fade_in),
-    "Wipe LTR": (wipe_out_to_black_ltr, wipe_in_from_black_ltr),
+    "Wipe Left-To-Right": (wipe_out_to_black_ltr, wipe_in_from_black_ltr),
     # Add more transitions here in the future
 }
 

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -1,0 +1,54 @@
+import uasyncio as asyncio
+import time
+
+# Default fade duration in milliseconds
+DEFAULT_FADE_DURATION_MS = 500
+# Number of steps for the fade effect
+FADE_STEPS = 20
+
+async def _fade(screen_manager, start_brightness, end_brightness, duration_ms):
+    """Helper function to fade backlight."""
+    delta = (end_brightness - start_brightness) / FADE_STEPS
+    step_delay = duration_ms // FADE_STEPS
+
+    current_brightness = start_brightness
+    for _ in range(FADE_STEPS):
+        current_brightness += delta
+        # Clamp brightness between 0.0 and 1.0
+        clamped_brightness = max(0.0, min(1.0, current_brightness))
+        screen_manager.display.set_backlight(clamped_brightness)
+        await asyncio.sleep_ms(step_delay)
+
+    # Ensure final brightness is set exactly
+    screen_manager.display.set_backlight(end_brightness)
+
+async def fade_out(screen_manager, duration_ms=DEFAULT_FADE_DURATION_MS):
+    """Fade the screen backlight out (to black)."""
+    print("[Transition] Fading out...")
+    current_brightness = screen_manager.display.get_backlight() # Assuming get_backlight() exists or use a default like 1.0
+    # Pimoroni library might not have get_backlight, assume it starts at 1.0 if unavailable
+    # For now, let's assume it fades from 1.0
+    await _fade(screen_manager, 1.0, 0.0, duration_ms)
+    print("[Transition] Fade out complete.")
+
+
+async def fade_in(screen_manager, duration_ms=DEFAULT_FADE_DURATION_MS):
+    """Fade the screen backlight in (from black)."""
+    print("[Transition] Fading in...")
+    # Ensure screen starts black before fading in
+    screen_manager.display.set_backlight(0.0)
+    await asyncio.sleep_ms(50) # Small delay to ensure backlight is off
+    await _fade(screen_manager, 0.0, 1.0, duration_ms)
+    print("[Transition] Fade in complete.")
+
+
+# Dictionary mapping transition names to their functions (or None)
+# We store tuples: (exit_transition_func, entry_transition_func)
+TRANSITIONS = {
+    "None": (None, None),
+    "Fade": (fade_out, fade_in),
+    # Add more transitions here in the future
+}
+
+# List of available transition names for the UI
+AVAILABLE_TRANSITIONS = list(TRANSITIONS.keys())

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -133,6 +133,192 @@ async def wipe_in_from_black_ltr(screen_manager, applet_to_draw, duration_ms=DEF
         screen_manager.display.remove_clip()
 
 
+async def wipe_out_to_black_rtl(screen_manager, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the current screen content out to black, right to left."""
+    print("[Transition] Wiping out RTL...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        for i in range(EFFECT_STEPS + 1):
+            current_x = width - ((width * i) // EFFECT_STEPS)
+            display.set_pen(black_pen)
+            display.rectangle(current_x, 0, width - current_x, height) # Draw from right edge inwards
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+        print("[Transition] Wipe out RTL complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe out RTL: {e}")
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+
+
+async def wipe_in_from_black_rtl(screen_manager, applet_to_draw, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the new applet content in over black, right to left."""
+    print("[Transition] Wiping in RTL...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+        await asyncio.sleep_ms(50)
+
+        for i in range(1, EFFECT_STEPS + 1):
+            current_width = (width * i) // EFFECT_STEPS
+            current_x = width - current_width
+            display.set_clip(current_x, 0, current_width, height) # Clip from right edge inwards
+
+            display.set_pen(black_pen)
+            display.clear()
+            await applet_to_draw.draw()
+
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+        print("[Transition] Wipe in RTL complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe in RTL: {e}")
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+    finally:
+        screen_manager.display.remove_clip()
+
+
+async def wipe_out_to_black_ttb(screen_manager, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the current screen content out to black, top to bottom."""
+    print("[Transition] Wiping out TTB...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        for i in range(EFFECT_STEPS + 1):
+            current_height = (height * i) // EFFECT_STEPS
+            display.set_pen(black_pen)
+            display.rectangle(0, 0, width, current_height) # Draw from top edge downwards
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+        print("[Transition] Wipe out TTB complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe out TTB: {e}")
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+
+
+async def wipe_in_from_black_ttb(screen_manager, applet_to_draw, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the new applet content in over black, top to bottom."""
+    print("[Transition] Wiping in TTB...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+        await asyncio.sleep_ms(50)
+
+        for i in range(1, EFFECT_STEPS + 1):
+            current_height = (height * i) // EFFECT_STEPS
+            display.set_clip(0, 0, width, current_height) # Clip from top edge downwards
+
+            display.set_pen(black_pen)
+            display.clear()
+            await applet_to_draw.draw()
+
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+        print("[Transition] Wipe in TTB complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe in TTB: {e}")
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+    finally:
+        screen_manager.display.remove_clip()
+
+
+async def wipe_out_to_black_btt(screen_manager, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the current screen content out to black, bottom to top."""
+    print("[Transition] Wiping out BTT...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        for i in range(EFFECT_STEPS + 1):
+            current_height = (height * i) // EFFECT_STEPS
+            current_y = height - current_height
+            display.set_pen(black_pen)
+            display.rectangle(0, current_y, width, current_height) # Draw from bottom edge upwards
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+        print("[Transition] Wipe out BTT complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe out BTT: {e}")
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+
+
+async def wipe_in_from_black_btt(screen_manager, applet_to_draw, duration_ms=DEFAULT_WIPE_DURATION_MS):
+    """Wipe the new applet content in over black, bottom to top."""
+    print("[Transition] Wiping in BTT...")
+    try:
+        display = screen_manager.display
+        width, height = display.get_bounds()
+        step_delay = duration_ms // EFFECT_STEPS
+        black_pen = screen_manager.get_pen(screen_manager.theme["BACKGROUND_COLOR"])
+
+        display.set_pen(black_pen)
+        display.rectangle(0, 0, width, height)
+        display.update()
+        await asyncio.sleep_ms(50)
+
+        for i in range(1, EFFECT_STEPS + 1):
+            current_height = (height * i) // EFFECT_STEPS
+            current_y = height - current_height
+            display.set_clip(0, current_y, width, current_height) # Clip from bottom edge upwards
+
+            display.set_pen(black_pen)
+            display.clear()
+            await applet_to_draw.draw()
+
+            display.update()
+            await asyncio.sleep_ms(step_delay)
+
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+        print("[Transition] Wipe in BTT complete.")
+    except Exception as e:
+        print(f"[Transition] Error during wipe in BTT: {e}")
+        display.remove_clip()
+        await applet_to_draw.draw()
+        display.update()
+    finally:
+        screen_manager.display.remove_clip()
+
+
 # Dictionary mapping transition names to their functions (or None)
 # We store tuples: (exit_transition_func, entry_transition_func)
 # Entry transition functions might require the applet instance as the second argument.
@@ -140,6 +326,9 @@ TRANSITIONS = {
     "None": (None, None),
     "Fade": (fade_out, fade_in),
     "Wipe Left-To-Right": (wipe_out_to_black_ltr, wipe_in_from_black_ltr),
+    "Wipe Right-To-Left": (wipe_out_to_black_rtl, wipe_in_from_black_rtl),
+    "Wipe Top-To-Bottom": (wipe_out_to_black_ttb, wipe_in_from_black_ttb),
+    "Wipe Bottom-To-Top": (wipe_out_to_black_btt, wipe_in_from_black_btt),
     # Add more transitions here in the future
 }
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -72,7 +72,9 @@ class AsyncWebServer:
         await writer.drain()
         
     async def handle_get_applets(self, request_lines, writer):
-        response_body = json.dumps(self.applets)
+        # Fetch the current applet list directly from the manager
+        applets_list = self.applet_manager.get_applets_list()
+        response_body = json.dumps(applets_list)
         response = (
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: application/json\r\n"

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -24,14 +24,15 @@ class AsyncWebServer:
     :param wifi_manager: An instance responsible for loading,
                          saving, and manipulating Wi-Fi credentials.
     """
-
-    def __init__(self, wifi_manager: wifi_manager.WiFiManager, applet_manager: applet_manager.AppletManager) -> None:
+    # Add config_manager parameter - This was the intended change
+    def __init__(self, wifi_manager: wifi_manager.WiFiManager, applet_manager: applet_manager.AppletManager, config_manager: ConfigManager) -> None:
         self.wifi_manager = wifi_manager
         self.applet_manager = applet_manager
+        self.config_manager = config_manager # Use the passed instance
         self.ip_address = self.wifi_manager.ip
 
-        # Initialize config manager
-        self.config_manager = ConfigManager()
+        # Remove instantiation here, use the passed instance
+        # self.config_manager = ConfigManager()
 
         # No need to cache applets here, get dynamically
         # self.applets = self.applet_manager.get_applets_list()

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -454,15 +454,15 @@ class AsyncWebServer:
         <label for="applet-duration" style="display: block; margin-bottom: 5px;">Applet Duration (seconds):</label>
         <input type="number" id="applet-duration" name="applet_duration" min="3" max="60" step="1" value="{applet_duration}" required>
         <p style="font-size: 12px; color: #ccc;">Duration must be between 3 and 60 seconds</p>
+
+        <label for="transition-effect" style="display: block; margin-top: 15px; margin-bottom: 5px;">Applet Transition Effect:</label>
+        <select id="transition-effect" name="transition_effect" style="width: 100%; padding: 10px; margin: 5px 0; border: none; border-radius: 5px; box-sizing: border-box; background-color: #fff; color: #000;">
+            <!-- Options will be populated by JavaScript -->
+        </select>
     
         <label for="timezone-offset" style="display: block; margin-top: 15px; margin-bottom: 5px;">Timezone Offset (hours from UTC):</label>
         <input type="number" id="timezone-offset" name="timezone_offset" min="-12" max="14" step="1" value="{timezone_offset}" required>
         <p style="font-size: 12px; color: #ccc;">Valid values between -12 and +14</p>
-
-        <label for="transition-effect" style="display: block; margin-top: 15px; margin-bottom: 5px;">Transition Effect:</label>
-        <select id="transition-effect" name="transition_effect" style="width: 100%; padding: 10px; margin: 5px 0; border: none; border-radius: 5px; box-sizing: border-box; background-color: #fff; color: #000;">
-            <!-- Options will be populated by JavaScript -->
-        </select>
 
         <button type="submit" style="margin-top: 15px; width: 100%;">Save Configuration</button>
     </form>


### PR DESCRIPTION
Added functionality to enable applet transition options. To do so in this feature the following is changed:

- New python transitions.py utility to help manage transitions
- Changes to web_server.py to select from a set of transitions
- Changes to applet_manager.py to include the transition effects in the applet loop
- Changes to main.py to make sure changes are loaded at runtime in the ConfigManager, no reboots of the devicec needed
- Changes to config.py to handle saving and retrieving of the selected effect option
- Changes to all applets to adjust draw() method to be able to run transition effects 
- Change to readme.md to include transitions.py and to draw attention to the new options under "Pro tips"
