### PR TITLE
Initialization options

### DIFF
--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -66,11 +66,20 @@ class AppletManager:
         print(f"[AppletManager] Applets updated and reloaded.")
 
     def get_applets_list(self):
+        saved_data = [] # Initialize to empty list
         try:
             with open("applets.json", "r") as f:
                 saved_data = json.load(f)
-        except:
-            saved_data = []
+        except OSError as e:
+             if e.args[0] == uerrno.ENOENT:
+                 print("[AppletManager] applets.json not found in get_applets_list. Returning defaults.")
+                 # Initializer should have created it, but proceed with defaults if missing.
+             else:
+                 print(f"[AppletManager] OS Error reading applets.json in get_applets_list: {e}")
+             # saved_data remains []
+        except ValueError:
+             print("[AppletManager] Value Error parsing applets.json in get_applets_list.")
+             # saved_data remains []
 
         # Default all known applets to disabled
         default_data = [{"name": name, "enabled": False} for name in self.all_applets.keys()]
@@ -82,6 +91,8 @@ class AppletManager:
         for entry in default_data:
             name = entry["name"]
             entry["enabled"] = applet_map.get(name, False)
+
+        return default_data # Return the merged list
 
 
     def load_applets(self, filename="applets.json"):

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -17,7 +17,8 @@ from applets import (
     moscow_time_applet,
     halving_countdown_applet,
     mempool_status_applet,
-    difficulty_applet
+    difficulty_applet,
+    ath_applet # Import the new applet
 )
 from config import ConfigManager
 
@@ -52,6 +53,7 @@ class AppletManager:
             "halving_countdown_applet": halving_countdown_applet.halving_countdown_applet,
             "mempool_status_applet": mempool_status_applet.mempool_status_applet,
             "difficulty_applet": difficulty_applet.difficulty_applet,
+            "ath_applet": ath_applet.ath_applet, # Add the new applet here
         }
         self.applets = self.load_applets()
 

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -83,20 +83,6 @@ class AppletManager:
             name = entry["name"]
             entry["enabled"] = applet_map.get(name, False)
 
-        return default_data
-
-    def _create_default_applets_file(self, filename="applets.json"):
-        """Creates a default applets.json file with bitcoin_applet enabled."""
-        print(f"[AppletManager] Creating default applet file: {filename}")
-        default_data = [{"name": "bitcoin_applet", "enabled": True}]
-        try:
-            with open(filename, "w") as f:
-                json.dump(default_data, f)
-            print(f"[AppletManager] Default {filename} created successfully.")
-            return default_data # Return the data we just wrote
-        except Exception as e:
-            print(f"[AppletManager] ERROR: Failed to create default {filename}: {e}")
-            return [] # Return empty list on creation failure
 
     def load_applets(self, filename="applets.json"):
         data = None
@@ -109,8 +95,10 @@ class AppletManager:
                 print(f"[AppletManager] Loaded applets from {filename}")
         except OSError as e:
             if e.args[0] == uerrno.ENOENT: # Check if the error is "No such file or directory"
-                print(f"[AppletManager] {filename} not found.")
-                data = self._create_default_applets_file(filename)
+                # File not found - Initializer should have created it.
+                # If it's still not here, something went wrong. Log error and return empty.
+                print(f"[AppletManager] ERROR: {filename} not found, even after initialization step. Returning empty applet list.")
+                return []
             else:
                 # Handle other potential OS errors (permissions, etc.)
                 print(f"[AppletManager] WARNING: OS error reading {filename}: {e}. Returning empty applet list.")

--- a/src/applets/ath_applet.py
+++ b/src/applets/ath_applet.py
@@ -74,7 +74,7 @@ class ath_applet(BaseApplet):
 
         # Check if ATH data is loaded
         if not self.ath_data or self.ath_data.get("ath_usd") is None:
-            self.screen_manager.draw_centered_text("ATH Data N/A")
+            self.screen_manager.draw_centered_text("ATH Data N/A", y_offset=90)
             gc.collect()
             return
 
@@ -82,11 +82,20 @@ class ath_applet(BaseApplet):
         ath_date_str = self.ath_data.get("ath_date_usd", "Unknown date")
         ath_date_formatted = ath_date_str.split("T")[0] if isinstance(ath_date_str, str) else "Unknown date"
 
-        # Draw ATH Price and Date
-        self.screen_manager.draw_text("ATH Price:", 15, 50, scale=2)
-        self.screen_manager.draw_text(f"${int(ath_price):,}", 15, 75, scale=3)
-        self.screen_manager.draw_text(f"Date: {ath_date_formatted}", 15, 110, scale=2)
-
+        # Draw ATH Price and Date - centered on screen
+        # Looking at bitcoin_applet.py, we see they're using absolute positions
+        # and the draw_centered_text has a different parameter style
+        
+        # Title centered at the top portion
+        self.screen_manager.draw_centered_text("BTC ATH", scale=3, y_offset=-60)
+        
+        # ATH Price - large and prominent in the center, matching bitcoin_applet's size
+        # In the bitcoin example, they don't specify scale for the price, meaning it uses default (likely 4)
+        self.screen_manager.draw_centered_text(f"${int(ath_price):,}")
+        
+        # Date below the price - moved down more to avoid overlap
+        self.screen_manager.draw_centered_text(f"Date: {ath_date_formatted}", scale=2, y_offset=40)
+        
         # Check if current price data is available
         current_price = None
         if isinstance(self.current_price_data, dict):
@@ -100,24 +109,24 @@ class ath_applet(BaseApplet):
                         print(f"[ath_applet] Error converting current price: {price_str}")
 
         # Calculate and draw percentage difference if current price is available
+        # Position this at the bottom portion but above the footer - moved down more
         if current_price is not None:
             try:
                 percentage_diff = ((current_price - ath_price) / ath_price) * 100
                 diff_text = f"Current: {percentage_diff:.2f}% vs ATH"
-
-                # Determine color based on difference (will always be negative or zero)
                 text_color = self.screen_manager.theme['NEGATIVE_COLOR'] if percentage_diff < 0 else self.screen_manager.theme['MAIN_FONT_COLOR']
-
-                # Draw percentage difference
-                self.screen_manager.draw_text(diff_text, 15, 150, scale=2, color=text_color)
-
+                
+                # Drawing at y_offset=70 (70 pixels below center) - adjusted from 80 to avoid footer
+                self.screen_manager.draw_centered_text(diff_text, scale=2, y_offset=70, color=text_color)
             except ZeroDivisionError:
-                 self.screen_manager.draw_text("Cannot calc % diff (ATH=0?)", 15, 150, scale=2, color=self.screen_manager.theme['NEGATIVE_COLOR'])
+                self.screen_manager.draw_centered_text("Cannot calc % diff (ATH=0?)", scale=2, y_offset=70, 
+                                                      color=self.screen_manager.theme['NEGATIVE_COLOR'])
             except Exception as e:
-                 print(f"[ath_applet] Error calculating percentage diff: {e}")
-                 self.screen_manager.draw_text("% Diff Error", 15, 150, scale=2, color=self.screen_manager.theme['NEGATIVE_COLOR'])
+                print(f"[ath_applet] Error calculating percentage diff: {e}")
+                self.screen_manager.draw_centered_text("% Diff Error", scale=2, y_offset=70,
+                                                     color=self.screen_manager.theme['NEGATIVE_COLOR'])
         else:
             # Current price not available
-            self.screen_manager.draw_text("Current Price: Loading...", 15, 150, scale=2)
+            self.screen_manager.draw_centered_text("Current Price: Loading...", scale=2, y_offset=70)
 
         gc.collect()

--- a/src/applets/ath_applet.py
+++ b/src/applets/ath_applet.py
@@ -1,0 +1,123 @@
+from screen_manager import ScreenManager
+from system_applets.base_applet import BaseApplet
+import ujson as json
+import os
+from data_manager import DataManager
+from micropython import const
+import gc
+import uerrno
+
+class ath_applet(BaseApplet):
+    """
+    Displays Bitcoin All-Time High (ATH) information:
+    - ATH Price (USD)
+    - ATH Date
+    - Percentage difference from current price to ATH
+    """
+    TTL = const(120) # Same TTL as bitcoin_applet for current price
+
+    def __init__(self, screen_manager: ScreenManager, data_manager: DataManager):
+        super().__init__('ath_applet', screen_manager)
+        self.data_manager = data_manager
+        # Need current price data, use the same endpoint as bitcoin_applet
+        self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
+        self.current_price_data = None # Store current price data fetched in update()
+        self.ath_data = None # Store ATH data loaded in start()
+        self.register()
+
+    def _load_ath_data(self):
+        """Load ATH data from the JSON file created by the initializer."""
+        try:
+            with open("bitcoin_ath.json", "r") as f:
+                self.ath_data = json.load(f)
+                print(f"[ath_applet] Loaded ATH data: {self.ath_data}")
+        except OSError as e:
+            if e.args[0] == uerrno.ENOENT:
+                print("[ath_applet] bitcoin_ath.json not found.")
+            else:
+                print(f"[ath_applet] Error loading bitcoin_ath.json: {e}")
+            self.ath_data = None # Ensure it's None on error
+        except ValueError:
+            print("[ath_applet] Error parsing bitcoin_ath.json.")
+            self.ath_data = None
+        except Exception as e:
+            print(f"[ath_applet] Unexpected error loading ATH data: {e}")
+            self.ath_data = None
+
+    def start(self):
+        # Reset data when applet starts
+        self.current_price_data = None
+        self._load_ath_data() # Load ATH data when applet starts
+        super().start()
+
+    def stop(self):
+        super().stop()
+
+    def register(self):
+        # Register endpoint for current price data
+        self.data_manager.register_endpoint(self.api_url, self.TTL)
+
+    async def update(self):
+        # Fetch current price data
+        self.current_price_data = self.data_manager.get_cached_data(self.api_url)
+        gc.collect()
+
+    async def draw(self):
+        self.screen_manager.clear()
+        self.screen_manager.draw_header("Bitcoin ATH Info")
+
+        # Draw footer with timestamp from current price data cache
+        timestamp = None
+        if isinstance(self.current_price_data, dict):
+            timestamp = self.current_price_data.get('timestamp', None)
+        self.screen_manager.draw_footer(timestamp)
+
+        # Check if ATH data is loaded
+        if not self.ath_data or self.ath_data.get("ath_usd") is None:
+            self.screen_manager.draw_centered_text("ATH Data N/A")
+            gc.collect()
+            return
+
+        ath_price = self.ath_data["ath_usd"]
+        ath_date_str = self.ath_data.get("ath_date_usd", "Unknown date")
+        ath_date_formatted = ath_date_str.split("T")[0] if isinstance(ath_date_str, str) else "Unknown date"
+
+        # Draw ATH Price and Date
+        self.screen_manager.draw_text("ATH Price:", 15, 50, scale=2)
+        self.screen_manager.draw_text(f"${int(ath_price):,}", 15, 75, scale=3)
+        self.screen_manager.draw_text(f"Date: {ath_date_formatted}", 15, 110, scale=2)
+
+        # Check if current price data is available
+        current_price = None
+        if isinstance(self.current_price_data, dict):
+            price_data = self.current_price_data.get('data', {})
+            if isinstance(price_data, dict):
+                price_str = price_data.get('lastPrice')
+                if price_str is not None:
+                    try:
+                        current_price = float(price_str)
+                    except (ValueError, TypeError):
+                        print(f"[ath_applet] Error converting current price: {price_str}")
+
+        # Calculate and draw percentage difference if current price is available
+        if current_price is not None:
+            try:
+                percentage_diff = ((current_price - ath_price) / ath_price) * 100
+                diff_text = f"Current: {percentage_diff:.2f}% vs ATH"
+
+                # Determine color based on difference (will always be negative or zero)
+                text_color = self.screen_manager.theme['NEGATIVE_COLOR'] if percentage_diff < 0 else self.screen_manager.theme['MAIN_FONT_COLOR']
+
+                # Draw percentage difference
+                self.screen_manager.draw_text(diff_text, 15, 150, scale=2, color=text_color)
+
+            except ZeroDivisionError:
+                 self.screen_manager.draw_text("Cannot calc % diff (ATH=0?)", 15, 150, scale=2, color=self.screen_manager.theme['NEGATIVE_COLOR'])
+            except Exception as e:
+                 print(f"[ath_applet] Error calculating percentage diff: {e}")
+                 self.screen_manager.draw_text("% Diff Error", 15, 150, scale=2, color=self.screen_manager.theme['NEGATIVE_COLOR'])
+        else:
+            # Current price not available
+            self.screen_manager.draw_text("Current Price: Loading...", 15, 150, scale=2)
+
+        gc.collect()

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -1,11 +1,8 @@
 from screen_manager import ScreenManager
 from system_applets.base_applet import BaseApplet
-import ujson as json
-import os
 from data_manager import DataManager
 from micropython import const
 import gc
-import uerrno
 
 class bitcoin_applet(BaseApplet):
     TTL = const(120)
@@ -17,12 +14,12 @@ class bitcoin_applet(BaseApplet):
         self.current_data = None # Store data fetched in update()
         self.register()
 
-   def start(self):
-       # Reset data when applet starts
-       self.current_data = None
-       super().start()
+    def start(self):
+        # Reset data when applet starts
+        self.current_data = None
+        super().start()
 
-   def stop(self):
+    def stop(self):
         # No need for drawn flag handling
         super().stop()
 
@@ -33,7 +30,9 @@ class bitcoin_applet(BaseApplet):
     async def update(self):
         # Fetch data in update
         self.current_data = self.data_manager.get_cached_data(self.api_url)
+        # print(f"[bitcoin_applet] Updated data: {self.current_data}") # Optional debug
         gc.collect()
+        # No need to call super().update()
 
     async def draw(self):
         # Draw uses data fetched by update()

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -121,21 +121,7 @@ class bitcoin_applet(BaseApplet):
                     # Draw the text (use default color)
                     self.screen_manager.draw_text(change_text, x, y, scale=2)
 
-                    # Draw ATH info if available
-                    if self.ath_data and self.ath_data.get("ath_usd") is not None:
-                        ath_price = self.ath_data["ath_usd"]
-                        ath_date_str = self.ath_data.get("ath_date_usd", "Unknown date")
-                        # Basic date formatting (extract YYYY-MM-DD)
-                        ath_date_formatted = ath_date_str.split("T")[0] if isinstance(ath_date_str, str) else "Unknown date"
-
-                        ath_text = f"ATH: ${int(ath_price):,} ({ath_date_formatted})"
-                        ath_y = self.screen_manager.height - 50 # Position near bottom, above footer
-                        self.screen_manager.draw_horizontal_centered_text(ath_text, ath_y, scale=1, color=self.screen_manager.theme['FOOTER_COLOR'])
-                    else:
-                        # Optionally draw placeholder if ATH data is missing
-                        ath_text = "ATH: N/A"
-                        ath_y = self.screen_manager.height - 50
-                        self.screen_manager.draw_horizontal_centered_text(ath_text, ath_y, scale=1, color=self.screen_manager.theme['FOOTER_COLOR'])
+                    # ATH info display removed from here, handled by ath_applet
 
                 except (ValueError, TypeError) as e:
                     print(f"[bitcoin_applet] Error converting values: {e}")

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -20,7 +20,6 @@ class bitcoin_applet(BaseApplet):
    def start(self):
        # Reset data when applet starts
        self.current_data = None
-       # _load_ath_data call removed
        super().start()
 
    def stop(self):
@@ -34,9 +33,7 @@ class bitcoin_applet(BaseApplet):
     async def update(self):
         # Fetch data in update
         self.current_data = self.data_manager.get_cached_data(self.api_url)
-        # print(f"[bitcoin_applet] Updated data: {self.current_data}") # Optional debug
         gc.collect()
-        # No need to call super().update()
 
     async def draw(self):
         # Draw uses data fetched by update()

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -13,12 +13,13 @@ class bitcoin_applet(BaseApplet):
     def __init__(self, screen_manager: ScreenManager, data_manager: DataManager):
         super().__init__('bitcoin_applet', screen_manager)
         self.data_manager = data_manager
-        self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
-        self.current_data = None # Store data fetched in update()
-        self.ath_data = None # Store ATH data loaded in start()
-        self.register()
+       self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
+       self.current_data = None # Store data fetched in update()
+       # self.ath_data removed
+       self.register()
 
-    def _load_ath_data(self):
+   # _load_ath_data method removed
+   # def _load_ath_data(self):
         """Load ATH data from the JSON file created by the initializer."""
         try:
             with open("bitcoin_ath.json", "r") as f:
@@ -29,21 +30,21 @@ class bitcoin_applet(BaseApplet):
                 print("[bitcoin_applet] bitcoin_ath.json not found.")
             else:
                 print(f"[bitcoin_applet] Error loading bitcoin_ath.json: {e}")
-            self.ath_data = None # Ensure it's None on error
+            # self.ath_data removed
         except ValueError:
             print("[bitcoin_applet] Error parsing bitcoin_ath.json.")
-            self.ath_data = None
+            # self.ath_data removed
         except Exception as e:
             print(f"[bitcoin_applet] Unexpected error loading ATH data: {e}")
-            self.ath_data = None
+            # self.ath_data removed
 
-    def start(self):
-        # Reset data when applet starts
-        self.current_data = None
-        self._load_ath_data() # Load ATH data when applet starts
-        super().start()
+   def start(self):
+       # Reset data when applet starts
+       self.current_data = None
+       # _load_ath_data call removed
+       super().start()
 
-    def stop(self):
+   def stop(self):
         # No need for drawn flag handling
         super().stop()
 

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -13,30 +13,9 @@ class bitcoin_applet(BaseApplet):
     def __init__(self, screen_manager: ScreenManager, data_manager: DataManager):
         super().__init__('bitcoin_applet', screen_manager)
         self.data_manager = data_manager
-       self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
-       self.current_data = None # Store data fetched in update()
-       # self.ath_data removed
-       self.register()
-
-   # _load_ath_data method removed
-   # def _load_ath_data(self):
-        """Load ATH data from the JSON file created by the initializer."""
-        try:
-            with open("bitcoin_ath.json", "r") as f:
-                self.ath_data = json.load(f)
-                print(f"[bitcoin_applet] Loaded ATH data: {self.ath_data}")
-        except OSError as e:
-            if e.args[0] == uerrno.ENOENT:
-                print("[bitcoin_applet] bitcoin_ath.json not found.")
-            else:
-                print(f"[bitcoin_applet] Error loading bitcoin_ath.json: {e}")
-            # self.ath_data removed
-        except ValueError:
-            print("[bitcoin_applet] Error parsing bitcoin_ath.json.")
-            # self.ath_data removed
-        except Exception as e:
-            print(f"[bitcoin_applet] Unexpected error loading ATH data: {e}")
-            # self.ath_data removed
+        self.api_url = "https://api.binance.com/api/v3/ticker/24hr?symbol=BTCUSDT"
+        self.current_data = None # Store data fetched in update()
+        self.register()
 
    def start(self):
        # Reset data when applet starts
@@ -121,8 +100,6 @@ class bitcoin_applet(BaseApplet):
 
                     # Draw the text (use default color)
                     self.screen_manager.draw_text(change_text, x, y, scale=2)
-
-                    # ATH info display removed from here, handled by ath_applet
 
                 except (ValueError, TypeError) as e:
                     print(f"[bitcoin_applet] Error converting values: {e}")

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -99,7 +99,10 @@ class Initializer:
                 gc.collect()
                 if status_line:
                     status_line_str = status_line.decode('utf-8').strip()
-                    print(f"[Initializer] Status Line: {status_line_str}")
+                    # --- ADD DEBUG PRINT HERE ---
+                    print(f"[Initializer] DEBUG: Raw line read: '{status_line_str}'")
+                    # ----------------------------
+                    print(f"[Initializer] Status Line: {status_line_str}") # Keep original print too
                     parts = status_line_str.split(" ")
                     if len(parts) > 1 and parts[0].startswith("HTTP/"):
                         try:

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -1,0 +1,239 @@
+import uasyncio as asyncio
+import os
+import ujson as json
+import gc
+import uerrno
+# Use the project's request library
+try:
+    import urllib_urequest as urequests
+except ImportError:
+    import urequests # Fallback if the aliased version isn't found
+
+from screen_manager import ScreenManager
+from config import ConfigManager # Assuming config might be needed later
+
+class Initializer:
+    """
+    Handles one-time initialization tasks after Wi-Fi connection.
+    - Ensures applets.json exists.
+    - Fetches and stores Bitcoin ATH data if not present.
+    """
+    ATH_API_URL = "https://api.coingecko.com/api/v3/coins/bitcoin?localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false"
+    APPLET_CONFIG_FILE = "applets.json"
+    ATH_DATA_FILE = "bitcoin_ath.json"
+    ATH_DUMP_FILE = "ath_dump.tmp" # Temporary file for raw API data
+
+    def __init__(self, screen_manager: ScreenManager, config_manager: ConfigManager):
+        self.screen_manager = screen_manager
+        self.config_manager = config_manager # Keep for potential future use
+
+    async def _show_initializing_screen(self, message="Initializing"):
+        """Displays an initializing message on the screen."""
+        self.screen_manager.clear()
+        dots = ""
+        for _ in range(3): # Simple animation loop
+            self.screen_manager.draw_centered_text(f"{message}{dots}", scale=2)
+            self.screen_manager.update()
+            await asyncio.sleep_ms(300)
+            dots += "."
+            if len(dots) > 3:
+                dots = ""
+            self.screen_manager.clear() # Clear previous text for animation
+
+        # Final message before proceeding
+        self.screen_manager.draw_centered_text(f"{message}...", scale=2)
+        self.screen_manager.update()
+        await asyncio.sleep_ms(100) # Brief pause on final message
+
+    def _file_exists(self, filename):
+        """Check if a file exists."""
+        try:
+            os.stat(filename)
+            return True
+        except OSError as e:
+            if e.args[0] == uerrno.ENOENT:
+                return False
+            else:
+                print(f"[Initializer] Error checking file {filename}: {e}")
+                return False # Treat other errors as non-existent for safety
+
+    def _ensure_applets_json(self):
+        """Creates a default applets.json if it doesn't exist."""
+        if not self._file_exists(self.APPLET_CONFIG_FILE):
+            print(f"[Initializer] {self.APPLET_CONFIG_FILE} not found. Creating default.")
+            default_data = [{"name": "bitcoin_applet", "enabled": True}]
+            try:
+                with open(self.APPLET_CONFIG_FILE, "w") as f:
+                    json.dump(default_data, f)
+                print(f"[Initializer] Default {self.APPLET_CONFIG_FILE} created.")
+            except Exception as e:
+                print(f"[Initializer] ERROR: Failed to create default {self.APPLET_CONFIG_FILE}: {e}")
+        else:
+            print(f"[Initializer] {self.APPLET_CONFIG_FILE} found.")
+
+    async def _fetch_and_process_ath(self):
+        """Fetches ATH data, saves relevant parts to bitcoin_ath.json."""
+        if self._file_exists(self.ATH_DATA_FILE):
+            print(f"[Initializer] {self.ATH_DATA_FILE} found. Skipping ATH fetch.")
+            return
+
+        print(f"[Initializer] {self.ATH_DATA_FILE} not found. Fetching ATH data...")
+        await self._show_initializing_screen("Fetching ATH")
+
+        response = None
+        try:
+            # WARNING: This reads the entire response into memory.
+            # If this causes MemoryError, a streaming approach is needed.
+            print(f"[Initializer] Requesting data from {self.ATH_API_URL}")
+            response = urequests.urlopen(self.ATH_API_URL)
+            gc.collect()
+
+            # Check status code
+            if response.status_code != 200:
+                print(f"[Initializer] Error fetching ATH data: Status {response.status_code}")
+                await self._show_initializing_screen(f"ATH Error {response.status_code}")
+                await asyncio.sleep(2)
+                return
+
+            print("[Initializer] Saving ATH response to temporary file...")
+            # Save to temporary file first to free memory before parsing attempt
+            with open(self.ATH_DUMP_FILE, "wb") as f:
+                # Read in chunks to potentially reduce peak memory slightly
+                chunk_size = 512
+                while True:
+                    chunk = response.raw.read(chunk_size)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    gc.collect() # Aggressive GC during write
+
+            response.close() # Close response to free memory
+            response = None
+            gc.collect()
+            print(f"[Initializer] Saved response to {self.ATH_DUMP_FILE}")
+
+            # --- Memory-Efficient Parsing Attempt ---
+            print(f"[Initializer] Parsing {self.ATH_DUMP_FILE} for ATH data...")
+            await self._show_initializing_screen("Processing ATH")
+            ath_usd = None
+            ath_date_usd = None
+            buffer = ""
+            in_market_data = False
+            brace_level = 0
+
+            try:
+                with open(self.ATH_DUMP_FILE, "r") as f:
+                    while True:
+                        chunk = f.read(256) # Read small chunks
+                        if not chunk:
+                            break
+
+                        if not in_market_data:
+                            # Search for the start of the market_data object
+                            key_index = chunk.find('"market_data":{')
+                            if key_index != -1:
+                                in_market_data = True
+                                buffer = chunk[key_index + len('"market_data":'):] # Start buffer after the key
+                                brace_level = 1 # We start inside the first {
+                                print("[Initializer] Found start of market_data")
+                        else:
+                            buffer += chunk
+
+                        # Process buffer only if we are inside market_data
+                        if in_market_data:
+                            # Simple brace counting (might be fragile with nested strings containing braces)
+                            for char in chunk: # Process the newly added chunk
+                                if char == '{':
+                                    brace_level += 1
+                                elif char == '}':
+                                    brace_level -= 1
+
+                            # Check if we found the end of the market_data object
+                            if brace_level == 0:
+                                print("[Initializer] Found end of market_data object.")
+                                # Attempt to parse just the market_data buffer
+                                try:
+                                    market_data_json = "{" + buffer.rstrip().rstrip(',') + "}" # Re-add braces, remove trailing comma if any
+                                    # print(f"Attempting to parse buffer: {market_data_json[:200]}...") # Debug: print start of buffer
+                                    market_data = json.loads(market_data_json)
+                                    ath_data = market_data.get("ath", {})
+                                    ath_usd = ath_data.get("usd")
+                                    ath_date_data = market_data.get("ath_date", {})
+                                    ath_date_usd = ath_date_data.get("usd")
+                                    print(f"[Initializer] Extracted ATH USD: {ath_usd}, Date: {ath_date_usd}")
+                                    break # Exit file reading loop
+                                except ValueError as json_e:
+                                    print(f"[Initializer] JSON parsing error for market_data buffer: {json_e}")
+                                    # print(f"Failed buffer content: {market_data_json}") # Debug: print failed buffer
+                                    # Could not parse, maybe brace counting failed? Stop processing.
+                                    break
+                                except Exception as parse_e:
+                                     print(f"[Initializer] Unexpected error parsing market_data buffer: {parse_e}")
+                                     break
+                        gc.collect() # GC frequently during parsing
+
+            except Exception as read_e:
+                print(f"[Initializer] Error reading/processing {self.ATH_DUMP_FILE}: {read_e}")
+
+            # --- Save extracted data ---
+            if ath_usd is not None and ath_date_usd is not None:
+                ath_output = {
+                    "ath_usd": ath_usd,
+                    "ath_date_usd": ath_date_usd
+                }
+                try:
+                    with open(self.ATH_DATA_FILE, "w") as f:
+                        json.dump(ath_output, f)
+                    print(f"[Initializer] Successfully saved ATH data to {self.ATH_DATA_FILE}")
+                except Exception as e:
+                    print(f"[Initializer] ERROR: Failed to write {self.ATH_DATA_FILE}: {e}")
+            else:
+                print(f"[Initializer] Failed to extract ATH data from {self.ATH_DUMP_FILE}.")
+                await self._show_initializing_screen("ATH Parse Fail")
+                await asyncio.sleep(2)
+
+        except urequests.HTTPError as e:
+             print(f"[Initializer] HTTPError fetching ATH data: {e}")
+             await self._show_initializing_screen(f"ATH HTTP Err")
+             await asyncio.sleep(2)
+        except MemoryError:
+            print("[Initializer] MemoryError during ATH fetch/process. Pico may not have enough RAM.")
+            await self._show_initializing_screen("ATH Mem Error")
+            await asyncio.sleep(2)
+        except Exception as e:
+            print(f"[Initializer] Unexpected error during ATH fetch: {e}")
+            await self._show_initializing_screen("ATH Error")
+            await asyncio.sleep(2)
+        finally:
+            # Clean up temporary file regardless of success
+            if self._file_exists(self.ATH_DUMP_FILE):
+                try:
+                    os.remove(self.ATH_DUMP_FILE)
+                    print(f"[Initializer] Removed temporary file {self.ATH_DUMP_FILE}")
+                except Exception as e:
+                    print(f"[Initializer] Error removing temporary file {self.ATH_DUMP_FILE}: {e}")
+            if response:
+                response.close()
+            gc.collect()
+
+
+    async def run_initialization(self):
+        """Runs all initialization steps."""
+        print("[Initializer] Starting initialization process...")
+        await self._show_initializing_screen("Initializing")
+
+        # 1. Ensure applets.json exists
+        self._ensure_applets_json()
+        gc.collect()
+        await asyncio.sleep_ms(100) # Small delay
+
+        # 2. Fetch and process ATH data if needed
+        await self._fetch_and_process_ath()
+        gc.collect()
+        await asyncio.sleep_ms(100) # Small delay
+
+        print("[Initializer] Initialization complete.")
+        await self._show_initializing_screen("Initialization Done")
+        await asyncio.sleep_ms(500) # Show "Done" briefly
+        self.screen_manager.clear()
+        self.screen_manager.update()

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -158,11 +158,9 @@ class Initializer:
                                 print("[Initializer] Found end of market_data object.")
                                 # Attempt to parse just the market_data buffer
                                 try:
-                                    # Construct the JSON string carefully. The buffer should contain the content *inside* the main braces.
-                                    market_data_json = "{" + buffer + "}"
-                                    # --- ADD DEBUG PRINT ---
-                                    print(f"[Initializer] DEBUG: Attempting to parse JSON string (first 500 chars): '{market_data_json[:500]}'")
-                                    # -----------------------
+                                    # The buffer should now contain the complete market_data object string
+                                    market_data_json = buffer
+                                    # print(f"[Initializer] DEBUG: Final buffer content (first 500): '{market_data_json[:500]}'") # Optional: Keep for further debugging if needed
                                     market_data = json.loads(market_data_json)
                                     ath_data = market_data.get("ath", {})
                                     ath_usd = ath_data.get("usd")

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -192,10 +192,7 @@ class Initializer:
                 await self._show_initializing_screen("ATH Parse Fail")
                 await asyncio.sleep(2)
 
-        except urequests.HTTPError as e:
-             print(f"[Initializer] HTTPError fetching ATH data: {e}")
-             await self._show_initializing_screen(f"ATH HTTP Err")
-             await asyncio.sleep(2)
+        # Removed specific urequests.HTTPError catch, rely on status code check and generic Exception
         except MemoryError:
             print("[Initializer] MemoryError during ATH fetch/process. Pico may not have enough RAM.")
             await self._show_initializing_screen("ATH Mem Error")

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -158,8 +158,11 @@ class Initializer:
                                 print("[Initializer] Found end of market_data object.")
                                 # Attempt to parse just the market_data buffer
                                 try:
-                                    market_data_json = "{" + buffer.rstrip().rstrip(',') + "}" # Re-add braces, remove trailing comma if any
-                                    # print(f"Attempting to parse buffer: {market_data_json[:200]}...") # Debug: print start of buffer
+                                    # Construct the JSON string carefully. The buffer should contain the content *inside* the main braces.
+                                    market_data_json = "{" + buffer + "}"
+                                    # --- ADD DEBUG PRINT ---
+                                    print(f"[Initializer] DEBUG: Attempting to parse JSON string (first 500 chars): '{market_data_json[:500]}'")
+                                    # -----------------------
                                     market_data = json.loads(market_data_json)
                                     ath_data = market_data.get("ath", {})
                                     ath_usd = ath_data.get("usd")

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from web_server import AsyncWebServer
 from applet_manager import AppletManager
 from system_applets import ap_applet
 from config import ConfigManager
+from initialization import Initializer # Import the new Initializer
 
 RGBLED(6, 7, 8).set_rgb(0, 0, 0)
 
@@ -42,9 +43,12 @@ async def main() -> None:
         else:
              print("[Main] WLAN disconnected unexpectedly after connect attempt.")
         config_manager.set_ip_address(ip_address)
+
+        # Start the main applet loop *after* initialization
         asyncio.create_task(applet_manager_instance.start_applets())
     else:
         print("[Main] No saved networks found or unable to connect. Setting up AP mode.")
+        # Optionally run parts of initializer even in AP mode? For now, only run in STA mode.
         # Optionally clear or set a specific IP when in AP mode
         config_manager.set_ip_address("AP Mode") # Or keep the last known IP / "N/A"
         wifi_manager.setup_ap()

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,9 @@ async def main() -> None:
 
     # Pass the single config_manager instance
     applet_manager_instance = AppletManager(screen_manager, data_manager, wifi_manager, config_manager)
+    # Create Initializer instance
+    initializer = Initializer(screen_manager, config_manager)
+
     splash_applet = applet_manager.SplashApplet(screen_manager)
     print("[Main] Starting splash applet.")
     await applet_manager_instance.run_applet_once(splash_applet)
@@ -34,6 +37,11 @@ async def main() -> None:
     # Attempt to connect to known Wi-Fi networks
     if wifi_manager.connect_to_saved_networks():
         print("[Main] Connected to a known Wi-Fi network.")
+
+        # --- Run Initializer ---
+        await initializer.run_initialization()
+        # ---------------------
+
         # Store the IP address after successful connection
         ip_address = "N/A"
         if wifi_manager.wlan.isconnected():


### PR DESCRIPTION
Add functionality to load and set values for items before applet loop starts. It is called  "Initialization" and loads after WiFi connection and before the applet loop. Benefit is that info that is needed only once or at startup doesn't need to be added to applet code and can take a bit longer to load to deal with the resource constraints on the Pico.

First functionality added to initialization step:
- Calling of Coingecko API to retrieve value and date of Bitcoin ATH and saving it to a file on the Pico
- Setting of default applet in applet.json to display a screen when nothing is selected

Change made to:
- initialization.py - To run the setup logic
- applet_manager.py - To remove setup items from it to keep it dedicated to applet handing
- main.py - To add calling of initialization step
- bitcoin_applet.py - Removal of ATH reference I put in there by mistake
- ath_applet.py - New applet to show ATH details. Selectable in the Web GUI.