### PR TITLE
Remove ticks on screen

### DIFF
--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -150,7 +150,11 @@ class AppletManager:
                 print(f"[AppletManager] Applet not found: {applet_name}")
                 continue
             # Instantiate the applet
-            applet_instance = applet_class(self.screen_manager, self.data_manager)
+            applet_instance = applet_class(
+                self.screen_manager, 
+                self.data_manager, 
+                self.config_manager  # Pass config_manager to all applets
+            )
             # Register its data requirements with the DataManager
             applet_instance.register()
             applets.append(applet_instance)

--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -152,8 +152,7 @@ class AppletManager:
             # Instantiate the applet
             applet_instance = applet_class(
                 self.screen_manager, 
-                self.data_manager, 
-                self.config_manager  # Pass config_manager to all applets
+                self.data_manager
             )
             # Register its data requirements with the DataManager
             applet_instance.register()

--- a/src/applets/fear_and_greed_applet.py
+++ b/src/applets/fear_and_greed_applet.py
@@ -5,6 +5,7 @@ from micropython import const
 import gc
 import ujson
 import time
+import ujson as json
 
 class fear_and_greed_applet(BaseApplet):
     """

--- a/src/applets/fear_and_greed_applet.py
+++ b/src/applets/fear_and_greed_applet.py
@@ -34,50 +34,25 @@ class fear_and_greed_applet(BaseApplet):
         super().stop()
 
     async def update(self):
-        # Get current timestamp and stored data from config
-        current_time = int(time.time())
-        fng_data = self.config_manager.get_fear_and_greed_index()
-        
-        # Check if data needs refreshing based on TTL
-        if (not fng_data['index'] or 
-            current_time - fng_data['timestamp'] > self.TTL):
-            
-            try:
-                response = self.data_manager.get_cached_data(self.API_URL)
-                
-                if response and 'data' in response:
-                    fng_data_list = response['data'].get('data', [])
-                    
-                    if fng_data_list:
-                        first_entry = fng_data_list[0]
-                        index_value = int(first_entry.get('value', 0))
-                        classification = first_entry.get('value_classification', 'N/A')
-                        
-                        # Update config with new data
-                        self.config_manager.set_fear_and_greed_index(
-                            index_value, 
-                            classification
-                        )
-                        
-                        # Refresh local data
-                        fng_data = {
-                            'index': index_value,
-                            'classification': classification
-                        }
-            
-            except Exception as e:
-                print(f"[FearAndGreedApplet] Update error: {e}")
-        
-        # Use the data (from config or just fetched)
-        self.current_data = {
-            'data': {
-                'data': [{
-                    'value': fng_data['index'],
-                    'value_classification': fng_data['classification']
-                }]
-            }
-        }
-        
+        # Try to load from a dedicated JSON file first
+        try:
+            with open("fng.json", "r") as f:
+                fng_data = json.load(f)
+                self.current_data = {
+                    'data': {
+                        'data': [{
+                            'value': fng_data.get('index', 0),
+                            'value_classification': fng_data.get('classification', 'N/A')
+                        }]
+                    }
+                }
+                return
+        except (OSError, ValueError):
+            # If file doesn't exist or is invalid, fall back to data manager
+            pass
+
+        # Fallback to data manager if JSON file not found
+        self.current_data = self.data_manager.get_cached_data(self.API_URL)
         gc.collect()
 
     def _calculate_color_for_index(self, index_value):

--- a/src/applets/fear_and_greed_applet.py
+++ b/src/applets/fear_and_greed_applet.py
@@ -17,8 +17,8 @@ class fear_and_greed_applet(BaseApplet):
     TTL = const(14400)
     API_URL = "https://api.alternative.me/fng/"
 
-    def __init__(self, screen_manager: ScreenManager, data_manager: DataManager):
-        super().__init__('fear_and_greed_applet', screen_manager)
+    def __init__(self, screen_manager: ScreenManager, data_manager: DataManager, config_manager=None):
+        super().__init__('fear_and_greed_applet', screen_manager, config_manager)
         self.data_manager = data_manager
         self.current_data = None
         self.register()

--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,10 @@ class ConfigManager:
             "applet_duration": 10,      # Default duration in seconds
             "timezone_offset": 0,       # Default timezone offset (UTC)
             "transition_effect": "None", # Default transition effect
-            "ip_address": "N/A"         # Default IP address
+            "ip_address": "N/A",         # Default IP address
+            "fear_and_greed_index": None,
+            "fear_and_greed_classification": None,
+            "fear_and_greed_timestamp": None
         }
         self.load_config()
 
@@ -130,3 +133,32 @@ class ConfigManager:
             print(f"[ConfigManager] Invalid transition effect '{effect_name}'. Not saving.")
             # Return the current valid value instead of saving an invalid one
             return self.get_transition_effect()
+
+    def get_fear_and_greed_index(self):
+        """Retrieve the stored Fear and Greed Index value."""
+        return {
+            "index": self.config.get("fear_and_greed_index", None),
+            "classification": self.config.get("fear_and_greed_classification", None),
+            "timestamp": self.config.get("fear_and_greed_timestamp", 0)
+        }
+
+    def set_fear_and_greed_index(self, index_value, classification):
+        """
+        Store Fear and Greed Index data.
+        
+        :param index_value: Numeric index (0-100)
+        :param classification: Text classification of the index
+        """
+        try:
+            index_value = int(index_value)
+            index_value = max(0, min(100, index_value))  # Clamp between 0-100
+            
+            self.config["fear_and_greed_index"] = index_value
+            self.config["fear_and_greed_classification"] = str(classification)
+            self.config["fear_and_greed_timestamp"] = int(time.time())
+            
+            self.save_config()
+            return True
+        except (ValueError, TypeError):
+            print("[ConfigManager] Invalid Fear and Greed Index data")
+            return False

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 class ConfigManager:
     """

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -320,9 +320,17 @@ class Initializer:
                     index_value = int(first_entry.get('value', 0))
                     classification = first_entry.get('value_classification', 'N/A')
 
-                    # Use config_manager to store the value
-                    self.config_manager.set_fear_and_greed_index(index_value, classification)
-                    print(f"[Initializer] Stored Fear and Greed Index: {index_value} ({classification})")
+                    # Save to a dedicated JSON file
+                    fng_output = {
+                        "index": index_value,
+                        "classification": classification
+                    }
+                    try:
+                        with open("fng.json", "w") as f:
+                            json.dump(fng_output, f)
+                        print(f"[Initializer] Successfully saved Fear and Greed Index to fng.json")
+                    except Exception as e:
+                        print(f"[Initializer] ERROR: Failed to write fng.json: {e}")
 
                 else:
                     print("[Initializer] Invalid Fear and Greed Index data structure")

--- a/src/system_applets/base_applet.py
+++ b/src/system_applets/base_applet.py
@@ -2,8 +2,9 @@ from screen_manager import ScreenManager
 
 
 class BaseApplet:
-    def __init__(self,applet_name, screen_manager, ticks_on_screen=5):
+    def __init__(self, applet_name, screen_manager, config_manager=None, ticks_on_screen=5):
         self.screen_manager: ScreenManager = screen_manager
+        self.config_manager = config_manager
         self.data_manager = None
         self.ticks_on_screen = ticks_on_screen
         self.ticks = 0

--- a/src/system_applets/base_applet.py
+++ b/src/system_applets/base_applet.py
@@ -2,16 +2,14 @@ from screen_manager import ScreenManager
 
 
 class BaseApplet:
-    def __init__(self, applet_name, screen_manager, config_manager=None, ticks_on_screen=5):
+    def __init__(self, applet_name, screen_manager, config_manager=None):
         self.screen_manager: ScreenManager = screen_manager
         self.config_manager = config_manager
         self.data_manager = None
-        self.ticks_on_screen = ticks_on_screen
-        self.ticks = 0
         self.data = None
         self.should_advance = False
         self.applet_name = applet_name
-        self.needs_redraw = True # Add needs_redraw flag
+        self.needs_redraw = True
 
     def getName(self)->str:
         return self.applet_name
@@ -35,9 +33,7 @@ class BaseApplet:
 
     async def update(self):
         """Called every frame to update the applet's state."""
-        print(f"Ticks: {self.ticks}")
-        self.ticks += 1
-        return self.should_advance or self.ticks >= self.ticks_on_screen
+        return self.should_advance
 
     async def draw(self):
         """Called every frame to draw the applet's output."""


### PR DESCRIPTION
The base applet had provisions for a system to count how long ticker applets were displayed called ticks_on_screen. It wasn't used anywhere so it is removed from the base applet now.

To do so I have updated base_applet.py where the functions for ticks_on_screen have been removed.