### PR TITLE
Fix/data manager hash

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -78,13 +78,13 @@ class DataManager:
 
     def _get_hash(self, url: str) -> str:
         """
-        Generate a hash for the URL using MD5 (first 8 hex chars).
+        Generate a hash for the URL using SHA256 (first 8 hex chars).
         Uses uhashlib which is built into MicroPython on RP2040.
         :param url: The URL to hash.
         :return: A hash string (8 hex characters, ~4 billion unique values).
         """
         url_bytes = url.encode('utf-8')
-        h = uhashlib.md5(url_bytes)
+        h = uhashlib.sha256(url_bytes)
         return ubinascii.hexlify(h.digest()).decode('ascii')[:8]
 
     def _get_cache_file_path(self, url: str) -> str:

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -3,6 +3,8 @@ import urequests
 import time
 import json
 import os
+import uhashlib
+import ubinascii
 from pimoroni import RGBLED
 
 
@@ -76,13 +78,14 @@ class DataManager:
 
     def _get_hash(self, url: str) -> str:
         """
-        Generate a hash for the URL using CRC32.
+        Generate a hash for the URL using MD5 (first 8 hex chars).
+        Uses uhashlib which is built into MicroPython on RP2040.
         :param url: The URL to hash.
-        :return: A hash as a string.
+        :return: A hash string (8 hex characters, ~4 billion unique values).
         """
-        # If possible, use a more robust function or a library like uhashlib
-        # For demonstration, we keep your approach
-        return str(sum(ord(c) for c in url) % 10000)
+        url_bytes = url.encode('utf-8')
+        h = uhashlib.md5(url_bytes)
+        return ubinascii.hexlify(h.digest()).decode('ascii')[:8]
 
     def _get_cache_file_path(self, url: str) -> str:
         """


### PR DESCRIPTION
The _get_hash() method in data_manager.py used a simple character sum (sum(ord(c) for c in url) % 10000) to generate cache filenames from URLs. This could produced collisions, i.e. different URLs mapping to the same hash, causing one API response to overwrite another's cached data.

Replaced with SHA256 via MicroPython's built-in uhashlib module, taking the first 8 hex characters (~4 billion unique values). uhashlib is available on RP2040 firmware, unlike hashlib.

Files changed: src/data_manager.py