### PR TITLE
Refactor/local footer timestamp

### DIFF
--- a/src/applets/moscow_time_applet.py
+++ b/src/applets/moscow_time_applet.py
@@ -2,6 +2,7 @@ from system_applets.base_applet import BaseApplet
 from data_manager import DataManager
 from micropython import const
 import gc
+import time
 
 class moscow_time_applet(BaseApplet):
     TTL = const(120)
@@ -43,8 +44,14 @@ class moscow_time_applet(BaseApplet):
             gc.collect()
             return
 
-        # Draw timestamp from the outer cache dictionary
-        self.screen_manager.draw_footer(self.current_data.get('timestamp', None))
+        # Draw timestamp from local RTC (NTP-synced)
+        try:
+            t = time.localtime()
+            timestamp_str = f"{t[2]:02d}-{t[1]:02d}-{t[0]} {t[3]:02d}:{t[4]:02d}:{t[5]:02d}"
+        except Exception as e:
+            timestamp_str = None
+            print(f"[moscow_time_applet] Failed to get local time: {e}")
+        self.screen_manager.draw_footer(timestamp_str)
 
         # Access the nested 'data' dictionary which holds the actual API response
         bitcoin_data = self.current_data.get('data', {})

--- a/src/applets/moscow_time_applet.py
+++ b/src/applets/moscow_time_applet.py
@@ -46,12 +46,11 @@ class moscow_time_applet(BaseApplet):
 
         # Draw timestamp from local RTC (NTP-synced)
         try:
-            t = time.localtime()
-            timestamp_str = f"{t[2]:02d}-{t[1]:02d}-{t[0]} {t[3]:02d}:{t[4]:02d}:{t[5]:02d}"
+            timestamp = int(time.time())
         except Exception as e:
-            timestamp_str = None
+            timestamp = None
             print(f"[moscow_time_applet] Failed to get local time: {e}")
-        self.screen_manager.draw_footer(timestamp_str)
+        self.screen_manager.draw_footer(timestamp)
 
         # Access the nested 'data' dictionary which holds the actual API response
         bitcoin_data = self.current_data.get('data', {})


### PR DESCRIPTION
Refactored moscow_time_applet.py to pass a raw Unix timestamp to draw_footer() instead of a pre-formatted string, and use the local RTC clock as the time source for the footer display.

Files changed:
- moscow_time_applet.py