### PR TITLE
cleanup: remove stale 'removed' comments across codebase

### DIFF
--- a/src/applet_manager.py
+++ b/src/applet_manager.py
@@ -164,7 +164,6 @@ class AppletManager:
         return self.all_applets.get(name)
 
     async def start_applets(self) -> None:
-        # Removed redundant enabled_applets = self.applets
         # The loop below checks self.applets directly
 
         if not self.applets: # Check initial state
@@ -208,7 +207,6 @@ class AppletManager:
             print(f"[AppletManager] Stopping applet: {self.current_applet.__class__.__name__}")
             # Get the *current* transition setting just before potentially running the exit transition
             selected_transition_name = self.config_manager.get_transition_effect()
-            # print(f"[AppletManager] Read transition for exit: '{selected_transition_name}'") # REMOVED LOGGING
             exit_transition, _ = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need exit func here
             if exit_transition:
                 print(f"[AppletManager] Running exit transition: {selected_transition_name}")
@@ -227,7 +225,6 @@ class AppletManager:
         # --- Transition In ---
         # Get the *current* transition setting just before potentially running the entry transition
         selected_transition_name = self.config_manager.get_transition_effect()
-        # print(f"[AppletManager] Read transition for entry: '{selected_transition_name}'") # REMOVED LOGGING
         _, entry_transition = transitions.TRANSITIONS.get(selected_transition_name, (None, None)) # Only need entry func here
 
         if entry_transition:

--- a/src/applets/bitcoin_applet.py
+++ b/src/applets/bitcoin_applet.py
@@ -109,5 +109,4 @@ class bitcoin_applet(BaseApplet):
             print(f"[bitcoin_applet] Unexpected data type: {type(self.current_data)}")
 
         # screen_manager.update() is called by AppletManager or transition
-        # self.drawn flag removed
         gc.collect()

--- a/src/applets/bitcoin_eur_applet.py
+++ b/src/applets/bitcoin_eur_applet.py
@@ -107,5 +107,4 @@ class bitcoin_eur_applet(BaseApplet):
             print(f"[bitcoin_eur_applet] Unexpected data type: {type(self.current_data)}")
 
         # screen_manager.update() is called by AppletManager or transition
-        # self.drawn flag removed
         gc.collect()

--- a/src/applets/difficulty_applet.py
+++ b/src/applets/difficulty_applet.py
@@ -137,5 +137,4 @@ class difficulty_applet(BaseApplet):
         y += 26
 
         # screen_manager.update() is called by AppletManager or transition
-        # self.drawn flag removed
         gc.collect()

--- a/src/applets/fee_applet.py
+++ b/src/applets/fee_applet.py
@@ -69,4 +69,3 @@ class fee_applet(BaseApplet):
             y += 40 # Move to next line
 
         # screen_manager.update() is called by AppletManager or transition
-        # self.drawn flag removed

--- a/src/applets/mempool_status_applet.py
+++ b/src/applets/mempool_status_applet.py
@@ -11,7 +11,6 @@ class mempool_status_applet(BaseApplet):
         self.data_manager = data_manager
         self.api_url = "https://mempool.space/api/mempool"
         self.current_data = None # Store data fetched in update()
-        # self.previous_vsize removed
         self.register()
 
     def start(self):
@@ -77,7 +76,6 @@ class mempool_status_applet(BaseApplet):
             # Restore original position
             self.screen_manager.draw_centered_text(size_str, scale=6, y_offset=0)
 
-            # --- Removed Change Indicator ---
 
             # --- Draw Transaction Count ---
             # Restore original position
@@ -88,5 +86,4 @@ class mempool_status_applet(BaseApplet):
             self.screen_manager.draw_centered_text("Data Error")
 
         # screen_manager.update() is called by AppletManager or transition
-        # self.drawn flag removed
         gc.collect()

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -272,7 +272,6 @@ class Initializer:
                 await self._show_initializing_screen("ATH Parse Fail")
                 await asyncio.sleep(2)
 
-        # Removed specific urequests.HTTPError catch, rely on status code check and generic Exception
         except MemoryError:
             print("[Initializer] MemoryError during ATH fetch/process. Pico may not have enough RAM.")
             await self._show_initializing_screen("ATH Mem Error")
@@ -384,7 +383,6 @@ class Initializer:
 
         gc.collect()
 
-    # Version fetching removed as it doesn't work properly
 
     async def run_initialization(self):
         """Runs all initialization steps."""


### PR DESCRIPTION
Removed stale already "removed" comments across the codebase that no longer reference existing code. Pure cleanup, no functional changes.

Files changed:
- applet_manager.py
-  bitcoin_applet.py
-  bitcoin_eur_applet.py
-  difficulty_applet.py
-  fee_applet.py
-  mempool_status_applet.py
-  initialization.py