### PR TITLE
Feature: health check endpoint + API key authentication

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,80 @@ You can print the enclosure yourself! It's straightforward. Choose between the 2
 ### Laser Cutting Instructions
 The most difficult part to complete at home. All necessary files and measurements are available in the assets folder. My recommendation is to locate a laser cutting service in your area or place an order online. You'll need translucent black acrylic with 3mm thickness. While the sticker adds a nice finishing touch, it's optional rather than required.
 
+## 🩺 Health Check API
+
+The ticker exposes a `GET /health` endpoint that returns real-time device status as JSON. This is useful for monitoring, home automation integrations, or debugging.
+
+### Request
+```bash
+curl http://<ticker-ip>/health
+```
+
+### Response
+```json
+{
+  "status": "ok",
+  "wifi": {
+    "connected": true,
+    "ip": "192.168.1.23",
+    "rssi": -56
+  },
+  "uptime_seconds": 265,
+  "reset_reason": "pwron_reset",
+  "current_applet": "dominance_applet",
+  "active_applets": 6,
+  "free_memory": 93936
+}
+```
+
+### Fields
+- **status:** `"ok"` if WiFi is connected, `"degraded"` otherwise
+- **wifi:** connection state, IP address, and signal strength (RSSI in dBm)
+- **uptime_seconds:** time since last boot
+- **reset_reason:** why the device last restarted (e.g. `pwron_reset`, `soft_reset`, `wdt_reset`)
+- **current_applet:** the applet currently displayed
+- **active_applets:** number of enabled applets
+- **free_memory:** available RAM in bytes
+
+## 🔐 API Key Authentication (Optional)
+
+You can protect all API endpoints with an API key. When configured, every request (except public routes) must include a valid `Authorization: Bearer <key>` header.
+
+### Setup
+1. Open the ticker's settings page in your browser
+2. Enter an API key in the **API Key** field (leave empty for open access)
+3. Click **Save Configuration**
+
+### Usage
+```bash
+curl -H "Authorization: Bearer my-secret-key" http://<ticker-ip>/health
+curl -H "Authorization: Bearer my-secret-key" http://<ticker-ip>/config
+```
+
+### Public Routes (always accessible without auth)
+- `GET /` — settings page
+- `POST /submit` — WiFi network setup (access point mode)
+- `GET /config` — read configuration
+- `POST /update_config` — save configuration (including API key changes)
+
+Without an API key set, all endpoints are open. This makes it easy to get started — add authentication only when you need it.
+
+## 📶 WiFi Monitor
+
+The ticker includes an automatic WiFi monitor that detects disconnections and reconnects without a reboot. It uses exponential backoff to avoid hammering the network.
+
+### How It Works
+- Monitors WiFi connection state continuously
+- On disconnect: attempts reconnect with increasing intervals (30s, 60s, 120s…)
+- Resyncs NTP time after reconnect
+- Restores applet cycling automatically
+
+### Test It
+```bash
+curl -X POST http://<ticker-ip>/test_disconnect
+```
+The WiFi will disconnect and the monitor should reconnect within ~30 seconds. Check the serial output for `[WiFiMonitor]` log messages.
+
 ## 🔨 Development
 ### Project Structure
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -17,7 +17,8 @@ class ConfigManager:
             "timezone_offset": 0,       # Default timezone offset (UTC)
             "transition_effect": "None", # Default transition effect
             "ip_address": "N/A",         # Default IP address
-            "version": None            # Current version of the ticker software
+            "version": None,           # Current version of the ticker software
+            "api_key": ""             # API key for endpoint authentication (empty = no auth)
         }
         self.load_config()
 
@@ -149,6 +150,23 @@ class ConfigManager:
                 json.dump(data, f)
         except OSError as e:
             print(f"[ConfigManager] Error writing {filename}: {e}")
+
+    def get_api_key(self):
+        """Get the configured API key (empty string means no auth required)"""
+        return self.config.get("api_key", self.defaults["api_key"])
+
+    def set_api_key(self, api_key):
+        """
+        Set the API key for endpoint authentication.
+
+        :param api_key: String (non-empty to enable auth, empty to disable)
+        :return: The API key that was set
+        """
+        if isinstance(api_key, str):
+            self.config["api_key"] = api_key
+            self.save_config()
+            return api_key
+        return self.get_api_key()
 
     def get_version(self):
         """Get the current version of the ticker software"""

--- a/src/index.html
+++ b/src/index.html
@@ -240,6 +240,10 @@
     <input type="number" id="timezone-offset" name="timezone_offset" min="-12" max="14" step="1" value="{{TIMEZONE_OFFSET}}" required>
     <p style="font-size: 12px; color: #ccc;">Valid values between -12 and +14</p>
 
+    <label for="api-key" style="display: block; margin-top: 15px; margin-bottom: 5px;">API Key (optional):</label>
+    <input type="password" id="api-key" name="api_key" placeholder="Leave empty for open access" style="text-transform: none;">
+    <p style="font-size: 12px; color: #ccc;">When set, all endpoints require <code>Authorization: Bearer &lt;key&gt;</code> header.</p>
+
     <button type="submit" style="margin-top: 15px; width: 100%;">Save Configuration</button>
 </form>
 
@@ -247,6 +251,16 @@
 
 <script>
 const serverIP = "{{SERVER_IP}}";
+
+// API key auth helper
+function apiFetch(url, options = {}) {
+  const apiKey = sessionStorage.getItem('api_key');
+  if (apiKey) {
+    if (!options.headers) options.headers = {};
+    options.headers['Authorization'] = 'Bearer ' + apiKey;
+  }
+  return fetch(url, options);
+}
 
 // Fetch and render saved Wi-Fi networks
 async function fetchNetworks() {
@@ -469,6 +483,13 @@ async function fetchConfig() {
       if (transitionSelect) {
           transitionSelect.value = config.transition_effect;
       }
+      // Load API key
+      document.getElementById('api-key').value = config.api_key || '';
+      if (config.api_key) {
+        sessionStorage.setItem('api_key', config.api_key);
+      } else {
+        sessionStorage.removeItem('api_key');
+      }
     } else {
       alert('Failed to fetch configuration');
     }
@@ -623,6 +644,14 @@ async function saveConfig(event) {
       document.getElementById('applet-duration').value = result.applet_duration;
       document.getElementById('timezone-offset').value = result.timezone_offset;
       document.getElementById('transition-effect').value = result.transition_effect;
+      // Handle API key in response
+      if (result.api_key) {
+        sessionStorage.setItem('api_key', result.api_key);
+        document.getElementById('api-key').value = result.api_key;
+      } else {
+        sessionStorage.removeItem('api_key');
+        document.getElementById('api-key').value = '';
+      }
       alert('Configuration saved successfully!');
     } else {
       alert('Failed to save configuration');

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -2,6 +2,9 @@ from applet_manager import AppletManager
 import applet_manager
 import uasyncio as asyncio
 import json
+import machine
+import gc
+import time
 import wifi_manager  # Your custom WiFiManager module
 from config import ConfigManager  # Added import for ConfigManager
 
@@ -30,6 +33,7 @@ class AsyncWebServer:
         self.applet_manager = applet_manager
         self.config_manager = config_manager # Use the passed instance
         self.ip_address = self.wifi_manager.ip
+        self._boot_ticks = time.ticks_ms()
 
         # Remove instantiation here, use the passed instance
         # self.config_manager = ConfigManager()
@@ -50,9 +54,18 @@ class AsyncWebServer:
             "POST /update_config": self.handle_update_config,  # New route to update config
             "POST /reboot": self.handle_reboot,
             "POST /test_disconnect": self.handle_test_disconnect,
+            "GET /health": self.handle_health,
         }
-        
+        # Routes that don't require auth (unauthenticated access)
+        self._public_routes = {
+            "GET /",
+            "POST /submit",  # AP setup needs to add networks without auth
+            "GET /config",  # Settings page needs to read current config
+            "POST /update_config",  # Settings page needs to save config (including API key removal)
+        }
+
     async def handle_root(self, request_lines, writer):
+        gc.collect()
         html = self.web_page()
         response = (
             "HTTP/1.1 200 OK\r\n"
@@ -103,7 +116,8 @@ class AsyncWebServer:
         config = {
             "applet_duration": self.config_manager.get_applet_duration(),
             "timezone_offset": self.config_manager.get_timezone_offset(),
-            "transition_effect": self.config_manager.get_transition_effect() # Add transition effect
+            "transition_effect": self.config_manager.get_transition_effect(),
+            "api_key": self.config_manager.get_api_key()
         }
         response_body = json.dumps(config)
         response = (
@@ -188,14 +202,22 @@ class AsyncWebServer:
         _, body = self.parse_request_body(request_lines)
         try:
             params = json.loads(body)
-            applet_duration = params.get("applet_duration", self.config_manager.defaults["applet_duration"])
-            timezone_offset = params.get("timezone_offset", self.config_manager.defaults["timezone_offset"])
-            transition_effect = params.get("transition_effect", self.config_manager.defaults["transition_effect"])
 
-            # Update the configs with settings
-            actual_duration = self.config_manager.set_applet_duration(applet_duration)
-            actual_offset = self.config_manager.set_timezone_offset(timezone_offset)
-            actual_transition = self.config_manager.set_transition_effect(transition_effect) # Update transition
+            # Only update fields that are explicitly provided in the request
+            if "applet_duration" in params:
+                self.config_manager.set_applet_duration(params["applet_duration"])
+            if "timezone_offset" in params:
+                self.config_manager.set_timezone_offset(params["timezone_offset"])
+            if "transition_effect" in params:
+                self.config_manager.set_transition_effect(params["transition_effect"])
+            if "api_key" in params:
+                self.config_manager.set_api_key(params["api_key"])
+
+            # Read back actual values for response
+            actual_duration = self.config_manager.get_applet_duration()
+            actual_offset = self.config_manager.get_timezone_offset()
+            actual_transition = self.config_manager.get_transition_effect()
+            actual_api_key = self.config_manager.get_api_key()
 
             print(f"[AsyncWebServer] Updated config: duration={actual_duration}, tz={actual_offset}, transition={actual_transition}")
 
@@ -206,7 +228,8 @@ class AsyncWebServer:
                 json.dumps({
                     "applet_duration": actual_duration,
                     "timezone_offset": actual_offset,
-                    "transition_effect": actual_transition # Include transition in response
+                    "transition_effect": actual_transition,
+                    "api_key": actual_api_key
                 })
             )
         except Exception as e:
@@ -282,6 +305,56 @@ class AsyncWebServer:
             "Content-Type: text/plain\r\n"
             "Connection: close\r\n\r\n"
             "WiFi disconnected. Monitor should reconnect within 30s."
+        )
+        writer.write(response.encode('utf-8'))
+        await writer.drain()
+
+    async def handle_health(self, request_lines, writer):
+        """Health check endpoint returning device status as JSON."""
+        import network
+        wlan = self.wifi_manager.wlan
+        connected = wlan.isconnected()
+
+        uptime_ms = time.ticks_diff(time.ticks_ms(), self._boot_ticks)
+        uptime_s = uptime_ms // 1000
+
+        reset_cause = machine.reset_cause()
+        RESET_CAUSES = {}
+        for attr in ("PWRON_RESET", "HARD_RESET", "WDT_RESET", "DEEPSLEEP_RESET", "SOFT_RESET"):
+            if hasattr(machine, attr):
+                RESET_CAUSES[getattr(machine, attr)] = attr.lower()
+        reset_reason = RESET_CAUSES.get(reset_cause, str(reset_cause))
+
+        wifi_info = {
+            "connected": connected,
+            "ip": self.wifi_manager.ip if connected else None,
+            "rssi": wlan.status('rssi') if connected else None,
+        }
+
+        current_applet_name = None
+        if self.applet_manager.current_applet:
+            try:
+                current_applet_name = self.applet_manager.current_applet.__class__.__name__
+            except Exception:
+                current_applet_name = "unknown"
+
+        enabled_count = len(self.applet_manager.applets) if hasattr(self.applet_manager, 'applets') else 0
+
+        payload = {
+            "status": "ok" if connected else "degraded",
+            "wifi": wifi_info,
+            "uptime_seconds": uptime_s,
+            "reset_reason": reset_reason,
+            "current_applet": current_applet_name,
+            "active_applets": enabled_count,
+            "free_memory": gc.mem_free(),
+        }
+
+        response_body = json.dumps(payload)
+        response = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json\r\n"
+            "Connection: close\r\n\r\n" + response_body
         )
         writer.write(response.encode('utf-8'))
         await writer.drain()
@@ -382,6 +455,24 @@ class AsyncWebServer:
         self.applet_manager.update_applets(selected_applets)
 
     #
+    def _check_auth(self, method, path, request_lines):
+        """Check API key authentication. Returns True if authorized."""
+        api_key = self.config_manager.get_api_key()
+        if not api_key:
+            return True  # No key configured = open access
+
+        route_key = f"{method} {path}"
+        if route_key in self._public_routes:
+            return True  # Public routes always allowed
+
+        # Extract Authorization header from request lines
+        for line in request_lines:
+            if line.lower().startswith("authorization:"):
+                token = line.split(":", 1)[1].strip()
+                if token == f"Bearer {api_key}":
+                    return True
+        return False
+
     # -------------------- Request Handling --------------------
     #
     async def handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -438,6 +529,19 @@ class AsyncWebServer:
 
             # 5. Split into lines as expected by downstream logic
             request_lines_list = full_request_s.split("\r\n")
+
+            # Check authentication before route handling
+            if not self._check_auth(method, path, request_lines_list):
+                unauthorized = (
+                    "HTTP/1.1 401 Unauthorized\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Connection: close\r\n\r\n"
+                    '{"error": "unauthorized"}'
+                )
+                writer.write(unauthorized.encode('utf-8'))
+                await writer.drain()
+                await writer.aclose()
+                return
 
             # Match the route using the parsed method and path from step 1
             handler = self.routes.get(f"{method} {path}")


### PR DESCRIPTION
This PR replaces PR #42 after rebasing it on PR #41.

Adds GET /health endpoint returning device status as JSON (WiFi state, IP, RSSI, uptime, reset reason, current applet, active applet count, free memory). Also adds optional API key authentication. When configured, all endpoints require a Bearer token. The settings page auto loads the key on any device.

Instructions to use these feature have been added to readme.md.

Changed files: 
- src/web_server.py
- src/config.py
-  src/ index.html
- readme.md